### PR TITLE
Adapt to renamed repo and fix ci

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -26,7 +26,7 @@ jobs:
           # Matrix required to handle environment caching with Mambaforge
         - os: ubuntu-latest
           label: ubuntu-latest
-          prefix: /usr/share/miniconda3/envs/pypsa-africa
+          prefix: /usr/share/miniconda3/envs/pypsa-earth
 
     name: ${{ matrix.label }}
     runs-on: ${{ matrix.os }}
@@ -40,18 +40,18 @@ jobs:
 
     - name: Clone pypsa-earth
       run: |
-        git clone https://github.com/pypsa-meets-africa/pypsa-africa ../pypsa-africa
+        git clone https://github.com/pypsa-meets-africa/pypsa-earth ../pypsa-earth
 
     - name: Copy environment file
       run: |
-        cp ../pypsa-africa/envs/environment.yaml environment.yaml
+        cp ../pypsa-earth/envs/environment.yaml environment.yaml
 
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v2
       with:
         miniforge-variant: Mambaforge
         miniforge-version: latest
-        activate-environment: pypsa-africa
+        activate-environment: pypsa-earth
         use-mamba: true
 
     - name: Create environment cache
@@ -63,7 +63,7 @@ jobs:
 
     - name: Update environment due to outdated or unavailable cache
       if: steps.cache.outputs.cache-hit != 'true'
-      run: mamba env update -n pypsa-africa -f environment.yaml
+      run: mamba env update -n pypsa-earth -f environment.yaml
 
     - name: Test snakemake workflow
       run: |

--- a/.github/workflows/ci-mac.yaml
+++ b/.github/workflows/ci-mac.yaml
@@ -24,7 +24,7 @@ jobs:
         include:
         - os: macos-latest
           label: macos-latest
-          prefix: /Users/runner/miniconda3/envs/pypsa-africa
+          prefix: /Users/runner/miniconda3/envs/pypsa-earth
 
     name: ${{ matrix.label }}
     runs-on: ${{ matrix.os }}
@@ -38,18 +38,18 @@ jobs:
 
     - name: Clone pypsa-earth
       run: |
-        git clone https://github.com/pypsa-meets-africa/pypsa-africa ../pypsa-africa
+        git clone https://github.com/pypsa-meets-africa/pypsa-earth ../pypsa-earth
 
     - name: Copy environment file
       run: |
-        cp ../pypsa-africa/envs/environment.yaml environment.yaml
+        cp ../pypsa-earth/envs/environment.yaml environment.yaml
 
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v2
       with:
         miniforge-variant: Mambaforge
         miniforge-version: latest
-        activate-environment: pypsa-africa
+        activate-environment: pypsa-earth
         use-mamba: true
 
     - name: Create environment cache
@@ -61,7 +61,7 @@ jobs:
 
     - name: Update environment due to outdated or unavailable cache
       if: steps.cache.outputs.cache-hit != 'true'
-      run: mamba env update -n pypsa-africa -f environment.yaml
+      run: mamba env update -n pypsa-earth -f environment.yaml
 
     - name: Test snakemake workflow
       run: |

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -24,7 +24,7 @@ jobs:
         include:
         - os: windows-latest
           label: windows-latest
-          prefix: C:\Miniconda3\envs\pypsa-africa
+          prefix: C:\Miniconda3\envs\pypsa-earth
 
     name: ${{ matrix.label }}
     runs-on: ${{ matrix.os }}
@@ -38,18 +38,18 @@ jobs:
 
     - name: Clone pypsa-earth
       run: |
-        git clone https://github.com/pypsa-meets-africa/pypsa-africa ../pypsa-africa
+        git clone https://github.com/pypsa-meets-africa/pypsa-earth ../pypsa-earth
 
     - name: Copy environment file
       run: |
-        cp ../pypsa-africa/envs/environment.yaml environment.yaml
+        cp ../pypsa-earth/envs/environment.yaml environment.yaml
 
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v2
       with:
         miniforge-variant: Mambaforge
         miniforge-version: latest
-        activate-environment: pypsa-africa
+        activate-environment: pypsa-earth
         use-mamba: true
 
     - name: Create environment cache
@@ -61,7 +61,7 @@ jobs:
 
     - name: Update environment due to outdated or unavailable cache
       if: steps.cache.outputs.cache-hit != 'true'
-      run: mamba env update -n pypsa-africa -f environment.yaml
+      run: mamba env update -n pypsa-earth -f environment.yaml
 
     - name: Test snakemake workflow
       run: |

--- a/Snakefile
+++ b/Snakefile
@@ -28,9 +28,9 @@ wildcard_constraints:
 
 subworkflow pypsaearth:
     workdir:
-        "../pypsa-africa"
+        "../pypsa-earth"
     snakefile:
-        "../pypsa-africa/Snakefile"
+        "../pypsa-earth/Snakefile"
     configfile:
         "./config.pypsa-earth.yaml"
 
@@ -530,7 +530,7 @@ rule run_test:
     run:
         import yaml
 
-        with open("../pypsa-africa/test/config.test1.yaml") as file:
+        with open("../pypsa-earth/test/config.test1.yaml") as file:
 
             config_pypsaearth = yaml.full_load(file)
             config_pypsaearth["electricity"]["extendable_carriers"]["Store"] = []
@@ -545,5 +545,5 @@ rule run_test:
 
 rule clean:
     run:
-        shell("rm -r ../pypsa-africa/resources")
-        shell("rm -r ../pypsa-africa/networks")
+        shell("rm -r ../pypsa-earth/resources")
+        shell("rm -r ../pypsa-earth/networks")

--- a/config.yaml
+++ b/config.yaml
@@ -203,7 +203,7 @@ sector:
     OCGT: gas
     #Gen_Test: oil # Just for testing purposes
 
-# snapshots are originally set in PyPSA-Africa/config.yaml but used again by PyPSA-Earth-Sec
+# snapshots are originally set in PyPSA-Earth/config.yaml but used again by PyPSA-Earth-Sec
 snapshots:
   # arguments to pd.date_range
   start: "2013-01-01"

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -204,7 +204,7 @@ sector:
     OCGT: gas
     #Gen_Test: oil # Just for testing purposes
 
-# snapshots are originally set in PyPSA-Africa/config.yaml but used again by PyPSA-Earth-Sec
+# snapshots are originally set in PyPSA-Earth/config.yaml but used again by PyPSA-Earth-Sec
 snapshots:
   # arguments to pd.date_range
   start: "2013-03-1"


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR aims at fixing the references from pypsa-africa to pypsa-earth and re-enable the CI

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
