### PR TITLE
fix: change CI clone from africa to earth

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Clone pypsa-earth
       run: |
-        git clone https://github.com/pypsa-meets-africa/pypsa-earth ../pypsa-earth
+        git clone https://github.com/pypsa-meets-earth/pypsa-earth ../pypsa-earth
 
     - name: Copy environment file
       run: |

--- a/.github/workflows/ci-mac.yaml
+++ b/.github/workflows/ci-mac.yaml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Clone pypsa-earth
       run: |
-        git clone https://github.com/pypsa-meets-africa/pypsa-earth ../pypsa-earth
+        git clone https://github.com/pypsa-meets-earth/pypsa-earth ../pypsa-earth
 
     - name: Copy environment file
       run: |

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Clone pypsa-earth
       run: |
-        git clone https://github.com/pypsa-meets-africa/pypsa-earth ../pypsa-earth
+        git clone https://github.com/pypsa-meets-earth/pypsa-earth ../pypsa-earth
 
     - name: Copy environment file
       run: |


### PR DESCRIPTION
## Changes proposed in this Pull Request

Fix the CI which currently tries to clone from "Africa", now changed to "Earth"..

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
