### PR TITLE
Include config default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 __pycache__
 gurobi.log
 .vscode
-#config.yaml
+config.yaml
 
 # Folders
 /bak

--- a/Snakefile
+++ b/Snakefile
@@ -8,6 +8,7 @@ HTTP = HTTPRemoteProvider()
 if not exists("config.yaml"):
     copyfile("config.default.yaml", "config.yaml")
 
+
 configfile: "config.yaml"
 
 

--- a/Snakefile
+++ b/Snakefile
@@ -1,7 +1,12 @@
+from os.path import exists
+from shutil import copyfile
+
 from snakemake.remote.HTTP import RemoteProvider as HTTPRemoteProvider
 
 HTTP = HTTPRemoteProvider()
 
+if not exists("config.yaml"):
+    copyfile("config.default.yaml", "config.yaml")
 
 configfile: "config.yaml"
 

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -5,7 +5,7 @@ results_dir: results/
 summary_dir: results/
 costs_dir: data/ #TODO change to the equivalent of technology data
 
-run: test3
+run: runname
 
 foresight: overnight
 

--- a/config.pypsa-earth.yaml
+++ b/config.pypsa-earth.yaml
@@ -127,7 +127,7 @@ electricity:
     stats: "irena"  # False, = greenfield expansion, 'irena' uses IRENA stats to add expansion limits
     year: 2020  # Reference year, available years for IRENA stats are 2000 to 2020
     p_nom_min: 1  # any float, scales the minimum expansion acquired from stats, i.e. 110% of <years>'s capacities => p_nom_min: 1.1
-    p_nom_max: 2  # sets the expansion constraint, False to deactivate this option and use estimated renewable potentials determine by the workflow, float scales the p_nom_min factor accordingly
+    p_nom_max: false  # sets the expansion constraint, False to deactivate this option and use estimated renewable potentials determine by the workflow, float scales the p_nom_min factor accordingly
     technology_mapping:
       # Wind is the Fueltype in ppm.data.Capacity_stats, onwind, offwind-{ac,dc} the carrier in PyPSA-Earth
       Offshore: [offwind-ac, offwind-dc]


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request
This PR distributes a `config.default.yaml` and copies it to `config.yaml` for individual scenario setting. This way, we can keep a running default yaml but still make our own personal scenario explorations without changing major things.

Note: previously we had a very strict limit on RE potentials, which is now removed.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
