### PR TITLE
Add export location

### DIFF
--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -16,8 +16,8 @@ import logging
 import os
 from pathlib import Path
 
-import pandas as pd
 import geopandas as gpd
+import pandas as pd
 import pypsa
 from helpers import locate_bus, override_component_attrs
 
@@ -59,8 +59,8 @@ def add_export(n, hydrogen_buses_ports, export_h2):
     country_shape = country_shape.to_crs("EPSG:4326")
 
     # Get coordinates of the most western and northern point of the country and add a buffer of 2 degrees (equiv. to approx 220 km)
-    x_export = country_shape.geometry.centroid.x.min() -2
-    y_export = country_shape.geometry.centroid.y.max() +2
+    x_export = country_shape.geometry.centroid.x.min() - 2
+    y_export = country_shape.geometry.centroid.y.max() + 2
 
     # add export bus
     n.add(

--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -53,7 +53,6 @@ def select_ports(n):
 
 
 def add_export(n, hydrogen_buses_ports, export_h2):
-
     country_shape = gpd.read_file(snakemake.input["shapes_path"])
     # Find most northwestern point in country shape and get x and y coordinates
     country_shape = country_shape.to_crs("EPSG:4326")

--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -67,6 +67,8 @@ def add_export(n, hydrogen_buses_ports, export_h2):
         "Bus",
         "H2 export bus",
         carrier="H2",
+        x=x_export,
+        y=y_export,
     )
 
     # add export links


### PR DESCRIPTION
# Closes #165 

## Changes proposed in this Pull Request
The most northern and western point of a selected region is taken to get the coordinates for the h2 export bus, including a buffer of approx. 220 km.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
