### PR TITLE
add co2 constraint to replace old one by pypsa-earth

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -136,6 +136,7 @@ solar_thermal:
     azimuth: 180.
 
 sector:
+  co2_emission_limit: 54.79 #Mtons
   gas_network: true
   oil_network: true
   district_heating:

--- a/config.pypsa-earth.yaml
+++ b/config.pypsa-earth.yaml
@@ -21,7 +21,7 @@ scenario:
   clusters: [10]
   opts: [Co2L1-144H]
 
-countries: ["NA"]
+countries: ["MA"]
 # Can be replaced by country ["NG", "BJ"], continent ["Africa"] or user-specific region, see more at https://pypsa-earth.readthedocs.io/en/latest/configuration.html#top-level-configuration
 
 snapshots:
@@ -116,8 +116,8 @@ load_options:
 
 electricity:
   voltages: [220., 300., 380.]
-  co2limit: 4.0e+3  # European default, 0.05 * 3.1e9*0.5, needs to be adjusted for Africa
-  co2base: 1.487e+8  # European default, adjustment to Africa necessary
+  co2limit: 4.0e+100  # European default, 0.05 * 3.1e9*0.5, needs to be adjusted for Africa
+  co2base: 4.0e+100  # European default, adjustment to Africa necessary
   agg_p_nom_limits: data/agg_p_nom_minmax.csv
   hvdc_as_lines: true # should HVDC lines be modeled as `Line` or as `Link` component?
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -290,6 +290,23 @@ def add_co2_sequestration_limit(n, sns):
         n, lhs, "<=", rhs, "GlobalConstraint", "mu", axes=pd.Index([name]), spec=name
     )
 
+def add_emission_limit(n, sns):
+    co2_atmosphere = n.stores.loc[n.stores.carrier == "co2"].index
+
+    # if co2_stores.empty or ("Store", "e") not in n.variables.index:
+    #     return
+
+    vars_final_co2_stored = get_var(n, "Store", "e").loc[sns[-1], co2_atmosphere]
+
+    lhs = linexpr((1, vars_final_co2_stored)).sum()
+    rhs = (
+        n.config["sector"].get("co2_emission_limit", 50) * 1e6
+    )  # TODO change 200 limit (Europe)
+
+    name = "co2_emission_limit"
+    define_constraints(
+        n, lhs, "<=", rhs, "GlobalConstraint", "mu", axes=pd.Index([name]), spec=name
+    )
 
 def extra_functionality(n, snapshots):
     add_battery_constraints(n)
@@ -301,7 +318,7 @@ def extra_functionality(n, snapshots):
         if snakemake.config["H2_network_limit"]:
             add_h2_network_cap(n, snakemake.config["H2_network_limit"])
     add_co2_sequestration_limit(n, snapshots)
-
+    add_emission_limit(n, snapshots)
 
 def solve_network(n, config, opts="", **kwargs):
     solver_options = config["solving"]["solver"].copy()

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -135,6 +135,7 @@ solar_thermal:
     azimuth: 180.
 
 sector:
+  co2_emission_limit: 54.79 #Mtons
   gas_network: true
   oil_network: true
   district_heating:


### PR DESCRIPTION

## Changes proposed in this Pull Request
This PR adds a co2 limit that works by forcing the model to have co2 in the co2_emission that is smaller than or equal to the limit specified in the config file

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.