### PR TITLE
add missing color and make plot boundaries flexible

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -475,3 +475,4 @@ plotting:
     solid biomass transport: green
     H2 for industry: "#222222"
     H2 for shipping: "#6495ED"
+    biomass EOP: "green"

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -225,7 +225,7 @@ def plot_h2_infra(network):
         branch_components=["Link"],
         color_geomap={"ocean": "lightblue", "land": "oldlace"},
         ax=ax,
-        #boundaries=(-20, 0, 25, 40),
+        # boundaries=(-20, 0, 25, 40),
     )
 
     handles = make_legend_circles_for(
@@ -324,7 +324,7 @@ def plot_smr(network):
         branch_components=["Link"],
         color_geomap={"ocean": "lightblue", "land": "oldlace"},
         ax=ax,
-        #boundaries=(-20, 0, 25, 40),
+        # boundaries=(-20, 0, 25, 40),
     )
 
     handles = make_legend_circles_for(
@@ -388,7 +388,7 @@ def plot_transmission_topology(network):
 
     n.plot(
         branch_components=["Link", "Line"],
-        #boundaries=(-20, 0, 25, 40),
+        # boundaries=(-20, 0, 25, 40),
         color_geomap={"ocean": "lightblue", "land": "oldlace"},
         line_colors="darkblue",
         link_colors="turquoise",
@@ -672,7 +672,7 @@ def plot_map(
         line_widths=line_widths / linewidth_factor,
         link_widths=link_widths / linewidth_factor,
         ax=ax,
-        #boundaries=(-20, 0, 25, 40),
+        # boundaries=(-20, 0, 25, 40),
         geomap="10m",
         color_geomap={"ocean": "lightblue", "land": "oldlace"},
     )

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -225,7 +225,7 @@ def plot_h2_infra(network):
         branch_components=["Link"],
         color_geomap={"ocean": "lightblue", "land": "oldlace"},
         ax=ax,
-        boundaries=(-20, 0, 25, 40),
+        #boundaries=(-20, 0, 25, 40),
     )
 
     handles = make_legend_circles_for(
@@ -324,7 +324,7 @@ def plot_smr(network):
         branch_components=["Link"],
         color_geomap={"ocean": "lightblue", "land": "oldlace"},
         ax=ax,
-        boundaries=(-20, 0, 25, 40),
+        #boundaries=(-20, 0, 25, 40),
     )
 
     handles = make_legend_circles_for(
@@ -388,7 +388,7 @@ def plot_transmission_topology(network):
 
     n.plot(
         branch_components=["Link", "Line"],
-        boundaries=(-20, 0, 25, 40),
+        #boundaries=(-20, 0, 25, 40),
         color_geomap={"ocean": "lightblue", "land": "oldlace"},
         line_colors="darkblue",
         link_colors="turquoise",
@@ -672,7 +672,7 @@ def plot_map(
         line_widths=line_widths / linewidth_factor,
         link_widths=link_widths / linewidth_factor,
         ax=ax,
-        boundaries=(-20, 0, 25, 40),
+        #boundaries=(-20, 0, 25, 40),
         geomap="10m",
         color_geomap={"ocean": "lightblue", "land": "oldlace"},
     )


### PR DESCRIPTION

## Changes proposed in this Pull Request
Plot_network.py used to crash because of a missing technology color in the config file. The boundaries of the plot was hard set to Morocco. Both fixed now.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.

