### PR TITLE
Add global ports airports

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -74,12 +74,14 @@ rule solve_all_networks:
             **config["export"]
         ),
 
+
 rule prepare_ports:
     output:
         ports="data/ports.csv",
         # TODO move from data to resources
     script:
         "scripts/prepare_ports.py"
+
 
 rule prepare_sector_network:
     input:

--- a/Snakefile
+++ b/Snakefile
@@ -74,6 +74,12 @@ rule solve_all_networks:
             **config["export"]
         ),
 
+rule prepare_ports:
+    output:
+        ports="data/ports.csv",
+        # TODO move from data to resources
+    script:
+        "scripts/prepare_ports.py"
 
 rule prepare_sector_network:
     input:

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -31,7 +31,7 @@ policy_config:
 clustering_options:
   alternative_clustering: true
 
-countries: ['MA']
+countries: ['UA']
 
 H2_network: false
 H2_network_limit: 2000 #GWkm

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -31,7 +31,7 @@ policy_config:
 clustering_options:
   alternative_clustering: true
 
-countries: ['UA']
+countries: ['MA']
 
 H2_network: false
 H2_network_limit: 2000 #GWkm

--- a/scripts/prepare_ports.py
+++ b/scripts/prepare_ports.py
@@ -1,100 +1,73 @@
 # -*- coding: utf-8 -*-
-import logging
 import os
+import logging
 from pathlib import Path
+import helpers
+# from helpers import configure_logging
 
-import country_converter as coco
 import numpy as np
 import pandas as pd
-from _helpers import configure_logging
+import country_converter as coco
 
-logger = logging.getLogger(__name__)
-
-if __name__ == "__main__":
-    if "snakemake" not in globals():
-        from _helpers import mock_snakemake, sets_path_to_root
-
-        os.chdir(os.path.dirname(os.path.abspath(__file__)))
-        snakemake = mock_snakemake("prepare_ports")
-        sets_path_to_root("pypsa-earth-sec")
-    configure_logging(snakemake)
-
-    run = snakemake.config.get("run", {})
-    RDIR = run["name"] + "/" if run.get("name") else ""
-    store_path_data = Path.joinpath(Path().cwd(), "data")
-    country_list = country_list_to_geofk(snakemake.config["countries"])
-
+# logger = logging.getLogger(__name__)
 
 def download_ports():
     """
     Downloads the world ports index csv File and NOT as shape or other because it is updated on a monthly basis.
     The following csv file was downloaded from the webpage https://msi.nga.mil/Publications/WPI as a csv file that is updated monthly as mentioned on the webpage. The dataset contains 3711 ports.
     """
-    fn = "https://msi.nga.mil/api/publications/download?type=view&key=16920959/SFH00000/UpdatedPub150.csv"
-    storage_options = {"User-Agent": "Mozilla/5.0"}
+    fn = "https://msi.nga.mil/api/publications/download?type=view&key=16920959/SFH00000/UpdatedPub150.csv" 
+    storage_options = {'User-Agent': 'Mozilla/5.0'}
     wpi_csv = pd.read_csv(fn, index_col=0, storage_options=storage_options)
 
-    return wpi_csv
+    return(wpi_csv)
 
 
-def prepare_data():
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from helpers import mock_snakemake, sets_path_to_root
+
+        os.chdir(os.path.dirname(os.path.abspath(__file__)))
+        snakemake = mock_snakemake("prepare_ports")
+        sets_path_to_root("pypsa-earth-sec")
+    # configure_logging(snakemake)
+
+    # run = snakemake.config.get("run", {})
+    # RDIR = run["name"] + "/" if run.get("name") else ""
+    # store_path_data = Path.joinpath(Path().cwd(), "data")
+    # country_list = country_list_to_geofk(snakemake.config["countries"])'
+
+
     df = download_ports().copy()
 
     # Add ISO2 country code for each country
-    df = df.rename(
-        columns={
-            "Country Code": "country_full_name",
-            "Latitude": "y",
-            "Longitude": "x",
-            "Main Port Name": "name",
-        }
-    )
-    df["country"] = df.country_full_name.apply(
-        lambda x: coco.convert(names=x, to="ISO2", not_found=None)
-    )
+    df = df.rename(columns={"Country Code": "country_full_name", "Latitude": "y", "Longitude": "x", "Main Port Name": "name"})  
+    df["country"] = df.country_full_name.apply(lambda x: coco.convert(names=x, to='ISO2', not_found=None))
 
     # Drop small islands that have no ISO2:
-    df = df[df.country_full_name != "Wake Island"]
-    df = df[df.country_full_name != "Johnson Atoll"]
-    df = df[df.country_full_name != "Midway Islands"]
+    df = df[df.country_full_name != 'Wake Island']
+    df = df[df.country_full_name != 'Johnson Atoll']
+    df = df[df.country_full_name != 'Midway Islands']
 
     # Select the columns that we need to keep
     df = df.reset_index()
-    df = df[
-        [
-            "World Port Index Number",
-            "Region Name",
-            "name",
-            "Alternate Port Name",
-            "country",
-            "World Water Body",
-            "Liquified Natural Gas Terminal Depth (m)",
-            "Harbor Size",
-            "Harbor Type",
-            "Harbor Use",
-            "country_full_name",
-            "y",
-            "x",
-        ]
-    ]
+    df = df[['World Port Index Number','Region Name', 'name', 'Alternate Port Name', 'country', 'World Water Body', 'Liquified Natural Gas Terminal Depth (m)', 'Harbor Size', 'Harbor Type', 'Harbor Use', 'country_full_name', 'y', 'x']]
 
     # Drop ports that are very small and that have unknown size (Unknown size ports are in total 19 and not suitable for H2 - checked visually)
-    ports = df.loc[df["Harbor Size"].isin(["Small", "Large", "Medium"])]
+    ports = df.loc[df["Harbor Size"].isin(['Small', 'Large', 'Medium'])]
 
     ports.insert(8, "Harbor_size_nr", 1)
-    ports.loc[ports["Harbor Size"].isin(["Small"]), "Harbor_size_nr"] = 1
-    ports.loc[ports["Harbor Size"].isin(["Medium"]), "Harbor_size_nr"] = 2
-    ports.loc[ports["Harbor Size"].isin(["Large"]), "Harbor_size_nr"] = 3
+    ports.loc[ports["Harbor Size"].isin(['Small']), 'Harbor_size_nr'] = 1
+    ports.loc[ports["Harbor Size"].isin(['Medium']), 'Harbor_size_nr'] = 2
+    ports.loc[ports["Harbor Size"].isin(['Large']), 'Harbor_size_nr'] = 3
 
     df1 = ports.copy()
-    df1 = df1.groupby(["country_full_name"]).sum("Harbor_size_nr")
-    df1 = df1[["Harbor_size_nr"]]
-    df1 = df1.rename(columns={"Harbor_size_nr": "Total_Harbor_size_nr"})
+    df1 = df1.groupby(['country_full_name']).sum('Harbor_size_nr')
+    df1 = df1[['Harbor_size_nr']]
+    df1 = df1.rename(columns={'Harbor_size_nr': "Total_Harbor_size_nr"})
 
-    ports = ports.set_index("country_full_name").join(df1, how="left")
+    ports = ports.set_index('country_full_name').join(df1, how='left')
 
-    ports["Harbor_size_weight"] = (
-        ports["Harbor_size_nr"] / ports["Total_Harbor_size_nr"]
-    )
+    ports['fraction'] = ports['Harbor_size_nr']/ports['Total_Harbor_size_nr']
 
-    ports.to_csv(r"./data/ports.csv", sep=",", encoding="utf-8", header="true")
+    ports.to_csv(r'./data/ports.csv', sep=',', encoding='utf-8', header='true')

--- a/scripts/prepare_ports.py
+++ b/scripts/prepare_ports.py
@@ -1,26 +1,29 @@
 # -*- coding: utf-8 -*-
-import os
 import logging
+import os
 from pathlib import Path
-import helpers
-# from helpers import configure_logging
 
+import country_converter as coco
+import helpers
 import numpy as np
 import pandas as pd
-import country_converter as coco
+
+# from helpers import configure_logging
+
 
 # logger = logging.getLogger(__name__)
+
 
 def download_ports():
     """
     Downloads the world ports index csv File and NOT as shape or other because it is updated on a monthly basis.
     The following csv file was downloaded from the webpage https://msi.nga.mil/Publications/WPI as a csv file that is updated monthly as mentioned on the webpage. The dataset contains 3711 ports.
     """
-    fn = "https://msi.nga.mil/api/publications/download?type=view&key=16920959/SFH00000/UpdatedPub150.csv" 
-    storage_options = {'User-Agent': 'Mozilla/5.0'}
+    fn = "https://msi.nga.mil/api/publications/download?type=view&key=16920959/SFH00000/UpdatedPub150.csv"
+    storage_options = {"User-Agent": "Mozilla/5.0"}
     wpi_csv = pd.read_csv(fn, index_col=0, storage_options=storage_options)
 
-    return(wpi_csv)
+    return wpi_csv
 
 
 if __name__ == "__main__":
@@ -37,37 +40,61 @@ if __name__ == "__main__":
     # store_path_data = Path.joinpath(Path().cwd(), "data")
     # country_list = country_list_to_geofk(snakemake.config["countries"])'
 
-
     df = download_ports().copy()
 
     # Add ISO2 country code for each country
-    df = df.rename(columns={"Country Code": "country_full_name", "Latitude": "y", "Longitude": "x", "Main Port Name": "name"})  
-    df["country"] = df.country_full_name.apply(lambda x: coco.convert(names=x, to='ISO2', not_found=None))
+    df = df.rename(
+        columns={
+            "Country Code": "country_full_name",
+            "Latitude": "y",
+            "Longitude": "x",
+            "Main Port Name": "name",
+        }
+    )
+    df["country"] = df.country_full_name.apply(
+        lambda x: coco.convert(names=x, to="ISO2", not_found=None)
+    )
 
     # Drop small islands that have no ISO2:
-    df = df[df.country_full_name != 'Wake Island']
-    df = df[df.country_full_name != 'Johnson Atoll']
-    df = df[df.country_full_name != 'Midway Islands']
+    df = df[df.country_full_name != "Wake Island"]
+    df = df[df.country_full_name != "Johnson Atoll"]
+    df = df[df.country_full_name != "Midway Islands"]
 
     # Select the columns that we need to keep
     df = df.reset_index()
-    df = df[['World Port Index Number','Region Name', 'name', 'Alternate Port Name', 'country', 'World Water Body', 'Liquified Natural Gas Terminal Depth (m)', 'Harbor Size', 'Harbor Type', 'Harbor Use', 'country_full_name', 'y', 'x']]
+    df = df[
+        [
+            "World Port Index Number",
+            "Region Name",
+            "name",
+            "Alternate Port Name",
+            "country",
+            "World Water Body",
+            "Liquified Natural Gas Terminal Depth (m)",
+            "Harbor Size",
+            "Harbor Type",
+            "Harbor Use",
+            "country_full_name",
+            "y",
+            "x",
+        ]
+    ]
 
     # Drop ports that are very small and that have unknown size (Unknown size ports are in total 19 and not suitable for H2 - checked visually)
-    ports = df.loc[df["Harbor Size"].isin(['Small', 'Large', 'Medium'])]
+    ports = df.loc[df["Harbor Size"].isin(["Small", "Large", "Medium"])]
 
     ports.insert(8, "Harbor_size_nr", 1)
-    ports.loc[ports["Harbor Size"].isin(['Small']), 'Harbor_size_nr'] = 1
-    ports.loc[ports["Harbor Size"].isin(['Medium']), 'Harbor_size_nr'] = 2
-    ports.loc[ports["Harbor Size"].isin(['Large']), 'Harbor_size_nr'] = 3
+    ports.loc[ports["Harbor Size"].isin(["Small"]), "Harbor_size_nr"] = 1
+    ports.loc[ports["Harbor Size"].isin(["Medium"]), "Harbor_size_nr"] = 2
+    ports.loc[ports["Harbor Size"].isin(["Large"]), "Harbor_size_nr"] = 3
 
     df1 = ports.copy()
-    df1 = df1.groupby(['country_full_name']).sum('Harbor_size_nr')
-    df1 = df1[['Harbor_size_nr']]
-    df1 = df1.rename(columns={'Harbor_size_nr': "Total_Harbor_size_nr"})
+    df1 = df1.groupby(["country_full_name"]).sum("Harbor_size_nr")
+    df1 = df1[["Harbor_size_nr"]]
+    df1 = df1.rename(columns={"Harbor_size_nr": "Total_Harbor_size_nr"})
 
-    ports = ports.set_index('country_full_name').join(df1, how='left')
+    ports = ports.set_index("country_full_name").join(df1, how="left")
 
-    ports['fraction'] = ports['Harbor_size_nr']/ports['Total_Harbor_size_nr']
+    ports["fraction"] = ports["Harbor_size_nr"] / ports["Total_Harbor_size_nr"]
 
-    ports.to_csv(r'./data/ports.csv', sep=',', encoding='utf-8', header='true')
+    ports.to_csv(r"./data/ports.csv", sep=",", encoding="utf-8", header="true")

--- a/scripts/prepare_ports.py
+++ b/scripts/prepare_ports.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+import os
+import logging
+from pathlib import Path
+
+from _helpers import configure_logging
+
+import numpy as np
+import pandas as pd
+import country_converter as coco
+
+logger = logging.getLogger(__name__)
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from _helpers import mock_snakemake, sets_path_to_root
+
+        os.chdir(os.path.dirname(os.path.abspath(__file__)))
+        snakemake = mock_snakemake("prepare_ports")
+        sets_path_to_root("pypsa-earth-sec")
+    configure_logging(snakemake)
+
+    run = snakemake.config.get("run", {})
+    RDIR = run["name"] + "/" if run.get("name") else ""
+    store_path_data = Path.joinpath(Path().cwd(), "data")
+    country_list = country_list_to_geofk(snakemake.config["countries"])
+
+
+def download_ports():
+    """
+    Downloads the world ports index csv File and NOT as shape or other because it is updated on a monthly basis.
+    The following csv file was downloaded from the webpage https://msi.nga.mil/Publications/WPI as a csv file that is updated monthly as mentioned on the webpage. The dataset contains 3711 ports.
+    """
+    fn = "https://msi.nga.mil/api/publications/download?type=view&key=16920959/SFH00000/UpdatedPub150.csv" 
+    storage_options = {'User-Agent': 'Mozilla/5.0'}
+    wpi_csv = pd.read_csv(fn, index_col=0, storage_options=storage_options)
+
+    return(wpi_csv)
+    
+def prepare_data():
+    df = download_ports().copy()
+
+    # Add ISO2 country code for each country
+    df = df.rename(columns={"Country Code": "country_full_name", "Latitude": "y", "Longitude": "x", "Main Port Name": "name"})  
+    df["country"] = df.country_full_name.apply(lambda x: coco.convert(names=x, to='ISO2', not_found=None))
+
+    # Drop small islands that have no ISO2:
+    df = df[df.country_full_name != 'Wake Island']
+    df = df[df.country_full_name != 'Johnson Atoll']
+    df = df[df.country_full_name != 'Midway Islands']
+
+    # Select the columns that we need to keep
+    df = df.reset_index()
+    df = df[['World Port Index Number','Region Name', 'name', 'Alternate Port Name', 'country', 'World Water Body', 'Liquified Natural Gas Terminal Depth (m)', 'Harbor Size', 'Harbor Type', 'Harbor Use', 'country_full_name', 'y', 'x']]
+
+    # Drop ports that are very small and that have unknown size (Unknown size ports are in total 19 and not suitable for H2 - checked visually)
+    ports = df.loc[df["Harbor Size"].isin(['Small', 'Large', 'Medium'])]
+
+    ports.insert(8, "Harbor_size_nr", 1)
+    ports.loc[ports["Harbor Size"].isin(['Small']), 'Harbor_size_nr'] = 1
+    ports.loc[ports["Harbor Size"].isin(['Medium']), 'Harbor_size_nr'] = 2
+    ports.loc[ports["Harbor Size"].isin(['Large']), 'Harbor_size_nr'] = 3
+
+    df1 = ports.copy()
+    df1 = df1.groupby(['country_full_name']).sum('Harbor_size_nr')
+    df1 = df1[['Harbor_size_nr']]
+    df1 = df1.rename(columns={'Harbor_size_nr': "Total_Harbor_size_nr"})
+
+    ports = ports.set_index('country_full_name').join(df1, how='left')
+
+    ports['Harbor_size_weight'] = ports['Harbor_size_nr']/ports['Total_Harbor_size_nr']
+
+    ports.to_csv(r'./data/ports.csv', sep=',', encoding='utf-8', header='true')


### PR DESCRIPTION
# Closes https://github.com/pypsa-meets-earth/pypsa-earth-sec/issues/185.

## Changes proposed in this Pull Request
Added global ports as a rule. 
The data are automatically downloaded throught the script from: https://msi.nga.mil/Publications/WPI as a .csv
Then the data is prepared by using only small, medium and large ports and dropping the rest. 
Fraction is based on port sizr for each country.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
