### PR TITLE
Rotate xticks of summary plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # PyPSA-Earth-Sec: A Sector-Coupled Open Optimisation Model of the Global Energy System
 
-## Development Status: Version 0.0.1
+## Development Status: Version 0.0.2
 
 [![Status Linux](https://github.com/pypsa-meets-earth/pypsa-earth-sec/actions/workflows/ci-linux.yaml/badge.svg?branch=main&event=push)](https://github.com/pypsa-meets-earth/pypsa-earth-sec/actions/workflows/ci-linux.yaml)
 [![Status Mac](https://github.com/pypsa-meets-earth/pypsa-earth-sec/actions/workflows/ci-mac.yaml/badge.svg?branch=main&event=push)](https://github.com/pypsa-meets-earth/pypsa-earth-sec/actions/workflows/ci-mac.yaml)
@@ -71,7 +71,7 @@ The diagram below depicts one representative clustered node showing the combinat
   - Make sure `build_cutout` is set to `true`
 - In the terminal run the following commands:
   - Activate the environment: `conda activate pypsa-earth`
-  - Create the base network for the country by running : `snakemake -j a base_network`
+  - Create the base network for the country by running : `snakemake -j 1 base_network`
 
 
 - In the folder *pypsa-earth-sec* open a terminal/command window to be located at this path `~/pypsa-earth-sec/`

--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -203,7 +203,7 @@ def create_network_topology(
         topo_reverse = topo.copy()
         topo_reverse.rename(columns=swap_buses, inplace=True)
         topo_reverse.index = topo_reverse.apply(make_index, axis=1)
-        topo = topo.append(topo_reverse)
+        topo = pd.concat([topo, topo_reverse])
 
     return topo
 

--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -502,8 +502,8 @@ def get_GADM_layer(country_list, layer_id, update=False, outlogging=False):
         # in the GADM processing of sub-national zones
         geodf_temp["GADM_ID"] = geodf_temp[f"GID_{code_layer}"]
 
-        # append geodataframes
-        geodf_list.append(geodf_temp)
+        # concatenate geodataframes
+        geodf_list = pd.concat([geodf_list, geodf_temp])
 
     geodf_GADM = gpd.GeoDataFrame(pd.concat(geodf_list, ignore_index=True))
     geodf_GADM.set_crs(geodf_list[0].crs, inplace=True)

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -179,7 +179,7 @@ def plot_h2_infra(network):
     # assign_location(n)
 
     bus_size_factor = 1e5
-    linewidth_factor = 1e3
+    linewidth_factor = 4e2
     # MW below which not drawn
     line_lower_threshold = 1e2
     bus_color = "m"
@@ -772,13 +772,14 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "plot_network",
             simpl="",
-            clusters="23",
+            clusters="4",
             ll="c1.0",
-            opts="Co2L",
+            opts="Co2L0.10",
             planning_horizons="2030",
-            sopts="144H",
+            sopts="6H",
             discountrate=0.071,
-            demand="NZ",
+            demand="DF",
+            h2export="120",
         )
 
     n = pypsa.Network(snakemake.input.network)

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -148,7 +148,7 @@ def plot_costs():
     # Sort columns by sum
     new_columns = (
         df.columns
-    )  # If you want to sort by values, then use: new_columns = df.columns.sort_values()
+    )  # If you want to sort by values, then use: new_columns = df.sum().sort_values().index
 
     fig, ax = plt.subplots(figsize=(12, 8))
 

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -146,8 +146,9 @@ def plot_costs():
     )
 
     # Sort columns by sum
-    new_columns = df.columns # If you want to sort by values, then use: new_columns = df.columns.sort_values()
-
+    new_columns = (
+        df.columns
+    )  # If you want to sort by values, then use: new_columns = df.columns.sort_values()
 
     fig, ax = plt.subplots(figsize=(12, 8))
 
@@ -209,7 +210,9 @@ def plot_energy():
         df.index.difference(preferred_order)
     )
 
-    new_columns = df.columns # If you want to sort by values, then use: new_columns = df.columns.sort_values()
+    new_columns = (
+        df.columns
+    )  # If you want to sort by values, then use: new_columns = df.columns.sort_values()
 
     fig, ax = plt.subplots(figsize=(12, 8))
 
@@ -238,7 +241,6 @@ def plot_energy():
         handles, labels, ncol=1, loc="upper left", bbox_to_anchor=[1, 1], frameon=False
     )
     plt.xticks(rotation=45, ha="right")
-
 
     fig.savefig(snakemake.output.energy, bbox_inches="tight")
 
@@ -291,7 +293,9 @@ def plot_balances():
             df.index.difference(preferred_order)
         )
 
-        new_columns = df.columns # If you want to sort by values, then use: new_columns = df.columns.sort_values()()
+        new_columns = (
+            df.columns
+        )  # If you want to sort by values, then use: new_columns = df.columns.sort_values()()
 
         fig, ax = plt.subplots(figsize=(12, 8))
 

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -545,8 +545,8 @@ if __name__ == "__main__":
 
     plot_balances()
 
-    for sector_opts in snakemake.config["scenario"]:
-        opts = sector_opts.split("-")
-        for o in opts:
-            if "cb" in o:
-                # plot_carbon_budget_distribution()
+    # for sector_opts in snakemake.config["scenario"]:
+    #     opts = sector_opts.split("-")
+    #     for o in opts:
+    #         if "cb" in o:
+    #            plot_carbon_budget_distribution()

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -6,10 +6,6 @@ import pandas as pd
 
 plt.style.use("ggplot")
 
-# from prepare_sector_network_eur_sec import (
-#     co2_emissions_year,  # Currently not required, only for carbon budget plotting
-# )
-
 
 # consolidate and rename
 def rename_techs(label):
@@ -423,112 +419,112 @@ def historical_emissions(cts):
     return emissions
 
 
-def plot_carbon_budget_distribution():
-    """
-    Plot historical carbon emissions in the EU and decarbonization path
-    """
+# def plot_carbon_budget_distribution():
+#     """
+#     Plot historical carbon emissions in the EU and decarbonization path
+#     """
 
-    import matplotlib.gridspec as gridspec
-    import seaborn as sns
+#     import matplotlib.gridspec as gridspec
+#     import seaborn as sns
 
-    sns.set()
-    sns.set_style("ticks")
-    plt.style.use("seaborn-ticks")
-    plt.rcParams["xtick.direction"] = "in"
-    plt.rcParams["ytick.direction"] = "in"
-    plt.rcParams["xtick.labelsize"] = 20
-    plt.rcParams["ytick.labelsize"] = 20
+#     sns.set()
+#     sns.set_style("ticks")
+#     plt.style.use("seaborn-ticks")
+#     plt.rcParams["xtick.direction"] = "in"
+#     plt.rcParams["ytick.direction"] = "in"
+#     plt.rcParams["xtick.labelsize"] = 20
+#     plt.rcParams["ytick.labelsize"] = 20
 
-    plt.figure(figsize=(10, 7))
-    gs1 = gridspec.GridSpec(1, 1)
-    ax1 = plt.subplot(gs1[0, 0])
-    ax1.set_ylabel("CO$_2$ emissions (Gt per year)", fontsize=22)
-    ax1.set_ylim([0, 5])
-    ax1.set_xlim([1990, snakemake.config["scenario"]["planning_horizons"][-1] + 1])
+#     plt.figure(figsize=(10, 7))
+#     gs1 = gridspec.GridSpec(1, 1)
+#     ax1 = plt.subplot(gs1[0, 0])
+#     ax1.set_ylabel("CO$_2$ emissions (Gt per year)", fontsize=22)
+#     ax1.set_ylim([0, 5])
+#     ax1.set_xlim([1990, snakemake.config["scenario"]["planning_horizons"][-1] + 1])
 
-    path_cb = snakemake.config["results_dir"] + snakemake.config["run"] + "/csvs/"
-    countries = pd.read_csv(path_cb + "countries.csv", index_col=1)
-    cts = countries.index.to_list()
-    e_1990 = co2_emissions_year(cts, opts, year=1990)
-    CO2_CAP = pd.read_csv(path_cb + "carbon_budget_distribution.csv", index_col=0)
+#     path_cb = snakemake.config["results_dir"] + snakemake.config["run"] + "/csvs/"
+#     countries = pd.read_csv(path_cb + "countries.csv", index_col=1)
+#     cts = countries.index.to_list()
+#     e_1990 = co2_emissions_year(cts, opts, year=1990)
+#     CO2_CAP = pd.read_csv(path_cb + "carbon_budget_distribution.csv", index_col=0)
 
-    ax1.plot(e_1990 * CO2_CAP[o], linewidth=3, color="dodgerblue", label=None)
+#     ax1.plot(e_1990 * CO2_CAP[o], linewidth=3, color="dodgerblue", label=None)
 
-    emissions = historical_emissions(cts)
+#     emissions = historical_emissions(cts)
 
-    ax1.plot(emissions, color="black", linewidth=3, label=None)
+#     ax1.plot(emissions, color="black", linewidth=3, label=None)
 
-    # plot commited and uder-discussion targets
-    # (notice that historical emissions include all countries in the
-    # network, but targets refer to EU)
-    ax1.plot(
-        [2020],
-        [0.8 * emissions[1990]],
-        marker="*",
-        markersize=12,
-        markerfacecolor="black",
-        markeredgecolor="black",
-    )
+#     # plot commited and uder-discussion targets
+#     # (notice that historical emissions include all countries in the
+#     # network, but targets refer to EU)
+#     ax1.plot(
+#         [2020],
+#         [0.8 * emissions[1990]],
+#         marker="*",
+#         markersize=12,
+#         markerfacecolor="black",
+#         markeredgecolor="black",
+#     )
 
-    ax1.plot(
-        [2030],
-        [0.45 * emissions[1990]],
-        marker="*",
-        markersize=12,
-        markerfacecolor="white",
-        markeredgecolor="black",
-    )
+#     ax1.plot(
+#         [2030],
+#         [0.45 * emissions[1990]],
+#         marker="*",
+#         markersize=12,
+#         markerfacecolor="white",
+#         markeredgecolor="black",
+#     )
 
-    ax1.plot(
-        [2030],
-        [0.6 * emissions[1990]],
-        marker="*",
-        markersize=12,
-        markerfacecolor="black",
-        markeredgecolor="black",
-    )
+#     ax1.plot(
+#         [2030],
+#         [0.6 * emissions[1990]],
+#         marker="*",
+#         markersize=12,
+#         markerfacecolor="black",
+#         markeredgecolor="black",
+#     )
 
-    ax1.plot(
-        [2050, 2050],
-        [x * emissions[1990] for x in [0.2, 0.05]],
-        color="gray",
-        linewidth=2,
-        marker="_",
-        alpha=0.5,
-    )
+#     ax1.plot(
+#         [2050, 2050],
+#         [x * emissions[1990] for x in [0.2, 0.05]],
+#         color="gray",
+#         linewidth=2,
+#         marker="_",
+#         alpha=0.5,
+#     )
 
-    ax1.plot(
-        [2050],
-        [0.01 * emissions[1990]],
-        marker="*",
-        markersize=12,
-        markerfacecolor="white",
-        linewidth=0,
-        markeredgecolor="black",
-        label="EU under-discussion target",
-        zorder=10,
-        clip_on=False,
-    )
+#     ax1.plot(
+#         [2050],
+#         [0.01 * emissions[1990]],
+#         marker="*",
+#         markersize=12,
+#         markerfacecolor="white",
+#         linewidth=0,
+#         markeredgecolor="black",
+#         label="EU under-discussion target",
+#         zorder=10,
+#         clip_on=False,
+#     )
 
-    ax1.plot(
-        [2050],
-        [0.125 * emissions[1990]],
-        "ro",
-        marker="*",
-        markersize=12,
-        markerfacecolor="black",
-        markeredgecolor="black",
-        label="EU commited target",
-    )
+#     ax1.plot(
+#         [2050],
+#         [0.125 * emissions[1990]],
+#         "ro",
+#         marker="*",
+#         markersize=12,
+#         markerfacecolor="black",
+#         markeredgecolor="black",
+#         label="EU commited target",
+#     )
 
-    ax1.legend(
-        fancybox=True, fontsize=18, loc=(0.01, 0.01), facecolor="white", frameon=True
-    )
+#     ax1.legend(
+#         fancybox=True, fontsize=18, loc=(0.01, 0.01), facecolor="white", frameon=True
+#     )
 
-    path_cb_plot = (
-        snakemake.config["results_dir"] + snakemake.config["run"] + "/graphs/"
-    )
-    plt.savefig(path_cb_plot + "carbon_budget_plot.pdf", dpi=300)
+#     path_cb_plot = (
+#         snakemake.config["results_dir"] + snakemake.config["run"] + "/graphs/"
+#     )
+#     plt.savefig(path_cb_plot + "carbon_budget_plot.pdf", dpi=300)
 
 
 if __name__ == "__main__":

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -545,16 +545,8 @@ if __name__ == "__main__":
 
     plot_balances()
 
-<<<<<<< HEAD
     # for sector_opts in snakemake.config["scenario"]:
     #     opts = sector_opts.split("-")
     #     for o in opts:
     #         if "cb" in o:
     #            plot_carbon_budget_distribution()
-=======
-    for sector_opts in snakemake.config["scenario"]:
-        opts = sector_opts.split("-")
-        for o in opts:
-            if "cb" in o:
-                # plot_carbon_budget_distribution()
->>>>>>> ff305f8ad16b9a66529666701010c6ad5634b404

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -331,93 +331,93 @@ def plot_balances():
         fig.savefig(snakemake.output.balances[:-10] + k + ".pdf", bbox_inches="tight")
 
 
-def historical_emissions(cts):
-    """
-    read historical emissions to add them to the carbon budget plot
-    """
-    # https://www.eea.europa.eu/data-and-maps/data/national-emissions-reported-to-the-unfccc-and-to-the-eu-greenhouse-gas-monitoring-mechanism-16
-    # downloaded 201228 (modified by EEA last on 201221)
-    fn = "data/eea/UNFCCC_v23.csv"
-    df = pd.read_csv(fn, encoding="latin-1")
-    df.loc[df["Year"] == "1985-1987", "Year"] = 1986
-    df["Year"] = df["Year"].astype(int)
-    df = df.set_index(
-        ["Year", "Sector_name", "Country_code", "Pollutant_name"]
-    ).sort_index()
+# def historical_emissions(cts):
+#     """
+#     read historical emissions to add them to the carbon budget plot
+#     """
+#     # https://www.eea.europa.eu/data-and-maps/data/national-emissions-reported-to-the-unfccc-and-to-the-eu-greenhouse-gas-monitoring-mechanism-16
+#     # downloaded 201228 (modified by EEA last on 201221)
+#     fn = "data/eea/UNFCCC_v23.csv"
+#     df = pd.read_csv(fn, encoding="latin-1")
+#     df.loc[df["Year"] == "1985-1987", "Year"] = 1986
+#     df["Year"] = df["Year"].astype(int)
+#     df = df.set_index(
+#         ["Year", "Sector_name", "Country_code", "Pollutant_name"]
+#     ).sort_index()
 
-    e = pd.Series()
-    e["electricity"] = "1.A.1.a - Public Electricity and Heat Production"
-    e["residential non-elec"] = "1.A.4.b - Residential"
-    e["services non-elec"] = "1.A.4.a - Commercial/Institutional"
-    e["rail non-elec"] = "1.A.3.c - Railways"
-    e["road non-elec"] = "1.A.3.b - Road Transportation"
-    e["domestic navigation"] = "1.A.3.d - Domestic Navigation"
-    e["international navigation"] = "1.D.1.b - International Navigation"
-    e["domestic aviation"] = "1.A.3.a - Domestic Aviation"
-    e["international aviation"] = "1.D.1.a - International Aviation"
-    e["total energy"] = "1 - Energy"
-    e["industrial processes"] = "2 - Industrial Processes and Product Use"
-    e["agriculture"] = "3 - Agriculture"
-    e["LULUCF"] = "4 - Land Use, Land-Use Change and Forestry"
-    e["waste management"] = "5 - Waste management"
-    e["other"] = "6 - Other Sector"
-    e["indirect"] = "ind_CO2 - Indirect CO2"
-    e["total wL"] = "Total (with LULUCF)"
-    e["total woL"] = "Total (without LULUCF)"
+#     e = pd.Series()
+#     e["electricity"] = "1.A.1.a - Public Electricity and Heat Production"
+#     e["residential non-elec"] = "1.A.4.b - Residential"
+#     e["services non-elec"] = "1.A.4.a - Commercial/Institutional"
+#     e["rail non-elec"] = "1.A.3.c - Railways"
+#     e["road non-elec"] = "1.A.3.b - Road Transportation"
+#     e["domestic navigation"] = "1.A.3.d - Domestic Navigation"
+#     e["international navigation"] = "1.D.1.b - International Navigation"
+#     e["domestic aviation"] = "1.A.3.a - Domestic Aviation"
+#     e["international aviation"] = "1.D.1.a - International Aviation"
+#     e["total energy"] = "1 - Energy"
+#     e["industrial processes"] = "2 - Industrial Processes and Product Use"
+#     e["agriculture"] = "3 - Agriculture"
+#     e["LULUCF"] = "4 - Land Use, Land-Use Change and Forestry"
+#     e["waste management"] = "5 - Waste management"
+#     e["other"] = "6 - Other Sector"
+#     e["indirect"] = "ind_CO2 - Indirect CO2"
+#     e["total wL"] = "Total (with LULUCF)"
+#     e["total woL"] = "Total (without LULUCF)"
 
-    pol = ["CO2"]  # ["All greenhouse gases - (CO2 equivalent)"]
-    cts
-    if "GB" in cts:
-        cts.remove("GB")
-        cts.append("UK")
+#     pol = ["CO2"]  # ["All greenhouse gases - (CO2 equivalent)"]
+#     cts
+#     if "GB" in cts:
+#         cts.remove("GB")
+#         cts.append("UK")
 
-    year = np.arange(1990, 2018).tolist()
+#     year = np.arange(1990, 2018).tolist()
 
-    idx = pd.IndexSlice
-    co2_totals = (
-        df.loc[idx[year, e.values, cts, pol], "emissions"]
-        .unstack("Year")
-        .rename(index=pd.Series(e.index, e.values))
-    )
+#     idx = pd.IndexSlice
+#     co2_totals = (
+#         df.loc[idx[year, e.values, cts, pol], "emissions"]
+#         .unstack("Year")
+#         .rename(index=pd.Series(e.index, e.values))
+#     )
 
-    co2_totals = (1 / 1e6) * co2_totals.groupby(level=0, axis=0).sum()  # Gton CO2
+#     co2_totals = (1 / 1e6) * co2_totals.groupby(level=0, axis=0).sum()  # Gton CO2
 
-    co2_totals.loc["industrial non-elec"] = (
-        co2_totals.loc["total energy"]
-        - co2_totals.loc[
-            [
-                "electricity",
-                "services non-elec",
-                "residential non-elec",
-                "road non-elec",
-                "rail non-elec",
-                "domestic aviation",
-                "international aviation",
-                "domestic navigation",
-                "international navigation",
-            ]
-        ].sum()
-    )
+#     co2_totals.loc["industrial non-elec"] = (
+#         co2_totals.loc["total energy"]
+#         - co2_totals.loc[
+#             [
+#                 "electricity",
+#                 "services non-elec",
+#                 "residential non-elec",
+#                 "road non-elec",
+#                 "rail non-elec",
+#                 "domestic aviation",
+#                 "international aviation",
+#                 "domestic navigation",
+#                 "international navigation",
+#             ]
+#         ].sum()
+#     )
 
-    emissions = co2_totals.loc["electricity"]
-    if "T" in opts:
-        emissions += co2_totals.loc[[i + " non-elec" for i in ["rail", "road"]]].sum()
-    if "H" in opts:
-        emissions += co2_totals.loc[
-            [i + " non-elec" for i in ["residential", "services"]]
-        ].sum()
-    if "I" in opts:
-        emissions += co2_totals.loc[
-            [
-                "industrial non-elec",
-                "industrial processes",
-                "domestic aviation",
-                "international aviation",
-                "domestic navigation",
-                "international navigation",
-            ]
-        ].sum()
-    return emissions
+#     emissions = co2_totals.loc["electricity"]
+#     if "T" in opts:
+#         emissions += co2_totals.loc[[i + " non-elec" for i in ["rail", "road"]]].sum()
+#     if "H" in opts:
+#         emissions += co2_totals.loc[
+#             [i + " non-elec" for i in ["residential", "services"]]
+#         ].sum()
+#     if "I" in opts:
+#         emissions += co2_totals.loc[
+#             [
+#                 "industrial non-elec",
+#                 "industrial processes",
+#                 "domestic aviation",
+#                 "international aviation",
+#                 "domestic navigation",
+#                 "international navigation",
+#             ]
+#         ].sum()
+#     return emissions
 
 
 # def plot_carbon_budget_distribution():

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -549,4 +549,4 @@ if __name__ == "__main__":
         opts = sector_opts.split("-")
         for o in opts:
             if "cb" in o:
-                plot_carbon_budget_distribution()
+                # plot_carbon_budget_distribution()

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -145,7 +145,9 @@ def plot_costs():
         df.index.difference(preferred_order)
     )
 
-    new_columns = df.sum().sort_values().index
+    # Sort columns by sum
+    new_columns = df.columns # If you want to sort by values, then use: new_columns = df.columns.sort_values()
+
 
     fig, ax = plt.subplots(figsize=(12, 8))
 
@@ -172,7 +174,7 @@ def plot_costs():
     ax.legend(
         handles, labels, ncol=1, loc="upper left", bbox_to_anchor=[1, 1], frameon=False
     )
-    plt.xticks(rotation=0)
+    plt.xticks(rotation=45, ha="right")
 
     fig.savefig(snakemake.output.costs, bbox_inches="tight")
 
@@ -207,7 +209,7 @@ def plot_energy():
         df.index.difference(preferred_order)
     )
 
-    new_columns = df.columns.sort_values()
+    new_columns = df.columns # If you want to sort by values, then use: new_columns = df.columns.sort_values()
 
     fig, ax = plt.subplots(figsize=(12, 8))
 
@@ -235,7 +237,8 @@ def plot_energy():
     ax.legend(
         handles, labels, ncol=1, loc="upper left", bbox_to_anchor=[1, 1], frameon=False
     )
-    plt.xticks(rotation=0)
+    plt.xticks(rotation=45, ha="right")
+
 
     fig.savefig(snakemake.output.energy, bbox_inches="tight")
 
@@ -288,7 +291,7 @@ def plot_balances():
             df.index.difference(preferred_order)
         )
 
-        new_columns = df.columns.sort_values()
+        new_columns = df.columns # If you want to sort by values, then use: new_columns = df.columns.sort_values()()
 
         fig, ax = plt.subplots(figsize=(12, 8))
 
@@ -322,7 +325,7 @@ def plot_balances():
             bbox_to_anchor=[1, 1],
             frameon=False,
         )
-        plt.xticks(rotation=0)
+        plt.xticks(rotation=45, ha="right")
 
         fig.savefig(snakemake.output.balances[:-10] + k + ".pdf", bbox_inches="tight")
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
The xticks in the `plot_summary` functions were not rotated. When plotting many scenarios with long names, they have overlapped. Here, a rotation of 45 degrees of the labels is introduced.
Also, the link width is increased to show hydrogen pipelines with low capacity.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
