### PR TITLE
Adaptation to 2-digit GADM id, matrix alignment, mock_snakemake directory

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -523,7 +523,7 @@ if config["custom_data"].get("industry_demand", False) == True:
             #shapes_path=pypsaearth("resources/bus_regions/regions_onshore_elec_s{simpl}_{clusters}.geojson")
             shapes_path="../pypsa-earth/resources/shapes/MAR2.geojson",
         output:
-            industrial_distribution_key="resources/industry/industrial_distribution_key_elec_s{simpl}_{clusters}.csv",
+            industrial_distribution_key="resources/demand/industrial_distribution_key_elec_s{simpl}_{clusters}.csv",
         threads: 1
         resources:
             mem_mb=1000,

--- a/scripts/build_industry_demand.py
+++ b/scripts/build_industry_demand.py
@@ -62,9 +62,6 @@ if __name__ == "__main__":
         prod_tom_path, header=0, index_col=0, keep_default_na=False
     )
 
-    if snakemake.config["custom_data"]["industry_demand"]:
-        production_tom.drop("Industry Machinery", axis=1, inplace=True)
-
     # to_drop=production_tom.sum()[production_tom.sum()==0].index
     # production_tom.drop(to_drop, axis=1, inplace=True)
 

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -768,7 +768,9 @@ nice_names_n = {
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from helpers import mock_snakemake
+        import os
 
+        os.chdir(os.path.dirname(os.path.abspath(__file__)))
         snakemake = mock_snakemake(
             "plot_network",
             simpl="",

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -767,8 +767,9 @@ nice_names_n = {
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from helpers import mock_snakemake
         import os
+
+        from helpers import mock_snakemake
 
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
         snakemake = mock_snakemake(

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -284,6 +284,7 @@ def plot_balances():
         if df.empty:
             continue
 
+        df.index = df.index.str.strip()
         new_index = preferred_order.intersection(df.index).append(
             df.index.difference(preferred_order)
         )
@@ -527,7 +528,9 @@ def plot_carbon_budget_distribution():
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from helpers import mock_snakemake
+        import os
 
+        os.chdir(os.path.dirname(os.path.abspath(__file__)))
         snakemake = mock_snakemake("plot_summary")
 
     n_header = 7  # Header lines in the csv files

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -527,8 +527,9 @@ def plot_carbon_budget_distribution():
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from helpers import mock_snakemake
         import os
+
+        from helpers import mock_snakemake
 
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
         snakemake = mock_snakemake("plot_summary")

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2249,12 +2249,6 @@ if __name__ == "__main__":
     # Load industry demand data
     industrial_demand = pd.read_csv(snakemake.input.industrial_demand)  # * 1e6
     print(industrial_demand)
-    if (
-        len(industrial_demand["TWh/a (MtCO2/a)"][0]) > 6
-    ):  # TODO do it nicely, this is done to catch the custom gadm
-        industrial_demand["TWh/a (MtCO2/a)"] = industrial_demand[
-            "TWh/a (MtCO2/a)"
-        ].apply(lambda cocode: two_2_three_digits_country(cocode[:2]) + cocode[2:])
 
     industrial_demand.set_index("TWh/a (MtCO2/a)", inplace=True)
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

- Alignment of prepare_sector network with 2-digit-id which is originally received in busmap of alternatively clustered network
- Prevention of dropping column which is necessary for industry demand calculation performed in line 86.
- Directory change for successful mock_snakemake execution when debugging plot_network and plot_summary scripts
- Removal of leading whitespace, which enables assignment of tech colors for balance summary plots

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
