### PR TITLE
Git submodules

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Fill submodule
       run: |
-        git submodule init
+        git submodule update --init
 
     - name: Copy environment file
       run: |

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -38,13 +38,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Clone pypsa-earth
+    - name: Fill submodule
       run: |
-        git clone https://github.com/pypsa-meets-earth/pypsa-earth ../pypsa-earth
+        git submodule init
 
     - name: Copy environment file
       run: |
-        cp ../pypsa-earth/envs/environment.yaml environment.yaml
+        cp ./pypsa-earth/envs/environment.yaml environment.yaml
 
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/ci-mac.yaml
+++ b/.github/workflows/ci-mac.yaml
@@ -36,13 +36,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Clone pypsa-earth
+    - name: Fill submodule
       run: |
-        git clone https://github.com/pypsa-meets-earth/pypsa-earth ../pypsa-earth
+        git submodule init
 
     - name: Copy environment file
       run: |
-        cp ../pypsa-earth/envs/environment.yaml environment.yaml
+        cp ./pypsa-earth/envs/environment.yaml environment.yaml
 
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/ci-mac.yaml
+++ b/.github/workflows/ci-mac.yaml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Fill submodule
       run: |
-        git submodule init
+        git submodule update --init
 
     - name: Copy environment file
       run: |

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -36,13 +36,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Clone pypsa-earth
+    - name: Fill submodule
       run: |
-        git clone https://github.com/pypsa-meets-earth/pypsa-earth ../pypsa-earth
+        git submodule init
 
     - name: Copy environment file
       run: |
-        cp ../pypsa-earth/envs/environment.yaml environment.yaml
+        cp ./pypsa-earth/envs/environment.yaml environment.yaml
 
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Fill submodule
       run: |
-        git submodule init
+        git submodule update --init
 
     - name: Copy environment file
       run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pypsa-earth"]
+	path = pypsa-earth
+	url = https://github.com/pypsa-meets-earth/pypsa-earth

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 **Disclaimer: PyPSA-Earth-Sec is still under development.**
 
-The workflow is adaped to work smoothly for the following countries: Morocco, Namibia, Nigeria and Benin. The spatial and temporal resolution of the model are felxible. It's advisable to use more than 3 nodes per country and a timestep not smaller than 3-hours. 
+The workflow is adaped to work smoothly for the following countries: Morocco, Namibia, Nigeria and Benin. The spatial and temporal resolution of the model are flexible. It's advisable to use more than 3 nodes per country and a timestep not smaller than 3-hours.
 
 
 Currently, no real sectoral demand data is used for the country inspected, instead, we use dummy data. The collection, compilation and processing of real data is underway.
@@ -27,7 +27,7 @@ The model now includes the following energy carriers: **electricity**, **hydroge
 
 The demand sectors covered are: **residential**, **industry**, **land transport**, **aviation**, **shipping**, **services** and agriculture.
 
-The diagram below depicts one representative clustered node showing the combination of carriers and sectors covered in the model as well as the generation and conversion technologies included. 
+The diagram below depicts one representative clustered node showing the combination of carriers and sectors covered in the model as well as the generation and conversion technologies included.
 
 ![alt text](https://github.com/pypsa-meets-earth/pypsa-earth-sec/blob/main/docs/pes_v0.0.2.png?raw=true)
 

--- a/README.md
+++ b/README.md
@@ -35,19 +35,19 @@ The diagram below depicts one representative clustered node showing the combinat
 
 ## Installation
 
-1. Open your terminal at a location where you want to install pypsa-earth-sec. Type the following in your terminal to download the package and the dependency (pypsa-earth) from GitHub:
+1. Open your terminal at a location where you want to install pypsa-earth-sec. Type the following in your terminal to download the package and the dependency (pypsa-earth) from GitHub.
+   Note that the tag `--recursive-submodules` is needed to automatically clone also the pypsa-earth dependency.
 
 ```bash
-    .../some/path/without/spaces % git clone https://github.com/pypsa-meets-earth/pypsa-earth.git
-    .../some/path/without/spaces % git clone https://github.com/pypsa-meets-earth/pypsa-earth-sec.git
+    .../some/path/without/spaces % git clone --recurse-submodules https://github.com/pypsa-meets-earth/pypsa-earth-sec.git
 ```
 
-2. The python package requirements are curated in the `envs/environment.yaml` file.
+2. The python package requirements are curated in the `envs/environment.yaml` file of the pypsa-earth repository.
    The environment can be installed using:
 
 ```bash
-    .../some/path/without/spaces % cd pypsa-earth
-    .../pypsa-earth % conda env create -f envs/environment.yaml
+    .../some/path/without/spaces % cd pypsa-earth-sec
+    .../pypsa-earth-sec % conda env create -f pypsa-earth/envs/environment.yaml
 ```
 
 3. For running the optimization one has to install the solver. We can recommend the open source HiGHs solver which installation manual is given [here](https://github.com/PyPSA/PyPSA/blob/633669d3f940ea256fb0a2313c7a499cbe0122a5/pypsa/linopt.py#L608-L632).
@@ -62,25 +62,12 @@ The diagram below depicts one representative clustered node showing the combinat
 
 ## Test run
 
-- In the folder *pypsa-earth* open a terminal window to be located at this path `~/pypsa-earth/`
-- Rename config.default.yaml to config.yaml. For instance in Linux:
-`mv config.default.yaml config.yaml`
-- Open the file `config.yaml` and 
-  - choose the country you want to model. For example
-    `countries: ["MA"]`
-  - Make sure `build_cutout` is set to `true`
-- In the terminal run the following commands:
-  - Activate the environment: `conda activate pypsa-earth`
-  - Create the base network for the country by running : `snakemake -j 1 base_network`
-
-
-- In the folder *pypsa-earth-sec* open a terminal/command window to be located at this path `~/pypsa-earth-sec/`
+- In the folder *pypsa-earth-sec* open a terminal/command window to be located at this path `./pypsa-earth-sec/`
 - Rename config.default.yaml to config.yaml. For instance in Linux:
 `mv config.default.yaml config.yaml`
 - Open the file `config.yaml` and follow the steps done before in pypsa-earth
   - choose the country you want to model. For example
     `countries: ["MA"]`
- - Open the file `config.pypsa-earth.yaml` and make sure `build_cutout` is set to `true`
 
 - Run a dryrun of the Snakemake workflow by typing simply in the terminal:
   ```bash

--- a/README.md
+++ b/README.md
@@ -38,27 +38,40 @@ The diagram below depicts one representative clustered node showing the combinat
 1. Open your terminal at a location where you want to install pypsa-earth-sec. Type the following in your terminal to download the package and the dependency (pypsa-earth) from GitHub.
    Note that the tag `--recursive-submodules` is needed to automatically clone also the pypsa-earth dependency.
 
-```bash
-    .../some/path/without/spaces % git clone --recurse-submodules https://github.com/pypsa-meets-earth/pypsa-earth-sec.git
-```
+   ```bash
+       .../some/path/without/spaces % git clone --recurse-submodules https://github.com/pypsa-meets-earth/pypsa-earth-sec.git
+   ```
 
-2. The python package requirements are curated in the `envs/environment.yaml` file of the pypsa-earth repository.
+2. Move the current directory to the head of the repository.
+   ```bash
+       .../some/path/without/spaces % cd pypsa-earth-sec
+   ```
+
+3. (optional) For reproducibility and compatibility purposes, it is possible to specify a specific version of the pypsa-earth submodule.
+   To do so, feel to reproduce the following lines, yet this is not mandatory.
+   If you desire to run the latest pypsa-earth model, please skip this point 3.
+
+   ```bash
+       .../pypsa-earth-sec % cd pypsa-earth
+       .../pypsa-earth % git reset --hard \{commit id\}
+       .../pypsa-earth % cd ..
+   ```
+
+4. The python package requirements are curated in the `envs/environment.yaml` file of the pypsa-earth repository.
    The environment can be installed using:
 
-```bash
-    .../some/path/without/spaces % cd pypsa-earth-sec
-    .../pypsa-earth-sec % conda env create -f pypsa-earth/envs/environment.yaml
-```
+   ```bash
+       .../pypsa-earth-sec % conda env create -f pypsa-earth/envs/environment.yaml
+   ```
 
-3. For running the optimization one has to install the solver. We can recommend the open source HiGHs solver which installation manual is given [here](https://github.com/PyPSA/PyPSA/blob/633669d3f940ea256fb0a2313c7a499cbe0122a5/pypsa/linopt.py#L608-L632).
+5. For running the optimization one has to install the solver. We can recommend the open source HiGHs solver which installation manual is given [here](https://github.com/PyPSA/PyPSA/blob/633669d3f940ea256fb0a2313c7a499cbe0122a5/pypsa/linopt.py#L608-L632).
 
-4. To use jupyter lab (new jupyter notebooks) **continue** with the [ipython kernel installation](http://echrislynch.com/2019/02/01/adding-an-environment-to-jupyter-notebooks/) and test if your jupyter lab works:
+6. To use jupyter lab (new jupyter notebooks) **continue** with the [ipython kernel installation](http://echrislynch.com/2019/02/01/adding-an-environment-to-jupyter-notebooks/) and test if your jupyter lab works:
 
-```bash
-    .../pypsa-earth % ipython kernel install --user --name=pypsa-earth
-
-    .../pypsa-earth % jupyter lab
-```
+   ```bash
+       .../pypsa-earth % ipython kernel install --user --name=pypsa-earth
+       .../pypsa-earth % jupyter lab
+   ```
 
 ## Test run
 

--- a/Snakefile
+++ b/Snakefile
@@ -11,6 +11,8 @@ if not exists("config.yaml"):
 
 configfile: "config.yaml"
 
+PYPSAEARTH_FOLDER = "./pypsa-earth"
+
 
 SDIR = config["summary_dir"] + config["run"]
 RDIR = config["results_dir"] + config["run"]
@@ -36,9 +38,9 @@ wildcard_constraints:
 
 subworkflow pypsaearth:
     workdir:
-        "../pypsa-earth"
+        PYPSAEARTH_FOLDER
     snakefile:
-        "../pypsa-earth/Snakefile"
+        PYPSAEARTH_FOLDER + "/Snakefile"
     configfile:
         "./config.pypsa-earth.yaml"
 
@@ -492,7 +494,7 @@ rule run_test:
     run:
         import yaml
 
-        with open("../pypsa-earth/config.tutorial.yaml") as file:
+        with open(PYPSAEARTH_FOLDER + "/config.tutorial.yaml") as file:
             config_pypsaearth = yaml.full_load(file)
             config_pypsaearth["electricity"]["extendable_carriers"]["Store"] = []
             config_pypsaearth["electricity"]["extendable_carriers"]["Link"] = []
@@ -507,8 +509,8 @@ rule run_test:
 
 rule clean:
     run:
-        shell("rm -r ../pypsa-earth/resources")
-        shell("rm -r ../pypsa-earth/networks")
+        shell("rm -r " + PYPSAEARTH_FOLDER + "/resources")
+        shell("rm -r " + PYPSAEARTH_FOLDER + "/networks")
 
 
 if config["custom_data"].get("industry_demand", False) == True:
@@ -521,7 +523,7 @@ if config["custom_data"].get("industry_demand", False) == True:
             clustered_pop_layout="resources/population_shares/pop_layout_elec_s{simpl}_{clusters}.csv",
             industrial_database="resources/custom_data/industrial_database.csv",
             #shapes_path=pypsaearth("resources/bus_regions/regions_onshore_elec_s{simpl}_{clusters}.geojson")
-            shapes_path="../pypsa-earth/resources/shapes/MAR2.geojson",
+            shapes_path=PYPSAEARTH_FOLDER + "/resources/shapes/MAR2.geojson",
         output:
             industrial_distribution_key="resources/industry/industrial_distribution_key_elec_s{simpl}_{clusters}.csv",
         threads: 1

--- a/Snakefile
+++ b/Snakefile
@@ -497,6 +497,7 @@ rule run_test:
 
         with open(PYPSAEARTH_FOLDER + "/config.tutorial.yaml") as file:
             config_pypsaearth = yaml.full_load(file)
+            config_pypsaearth["retrieve_databundle"] = {"show_progress": False}
             config_pypsaearth["electricity"]["extendable_carriers"]["Store"] = []
             config_pypsaearth["electricity"]["extendable_carriers"]["Link"] = []
             config_pypsaearth["electricity"]["co2limit"] = 7.75e7

--- a/Snakefile
+++ b/Snakefile
@@ -11,6 +11,7 @@ if not exists("config.yaml"):
 
 configfile: "config.yaml"
 
+
 PYPSAEARTH_FOLDER = "./pypsa-earth"
 
 

--- a/scripts/build_population_layouts.py
+++ b/scripts/build_population_layouts.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     )  # os.path.abspath(snakemake.config["atlite"]["cutout"])
     cutout = atlite.Cutout(cutout_path)
 
-    grid_cells = cutout.grid_cells()
+    grid_cells = cutout.grid.geometry.to_list()
 
     # nuts3 has columns country, gdp, pop, geometry
     nuts3 = gpd.read_file(snakemake.input.nuts3_shapes).set_index("GADM_ID")


### PR DESCRIPTION
# Closes #195 

## Changes proposed in this Pull Request
Revise pypsa-earth dependency with git submodules and revise atlite deprecation.

Major commands to reproduce this PR are:
`git submodule add {github url}` : adds the package at {github url} as a submodule within the current folder. Optionally commits/branches/... can be specified
Note that the version will fix the pypsa-earth version to the current commit.

To update the submodule version to the latest commit, the following command can be used followed by a commit&PR to the repo:
`git submodule update`

With the new version, it is recommended to clone the repo using
`git clone --recurse-submodules update {repo path}` to automatically clone the pypsa-earth-sec repo AND the pypsa-earth submodule. README has been updated accordingly.

If only `git clone update {repo path}` is used, hence without the --recurse-submodules, then the command `git submodule init` is needed to fill the repo.

I don't think this needs a release_note, but if not, I'll be happy to add it.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
