### PR TITLE
Include monthly matching of hydrogen

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "pypsa-earth"]
 	path = pypsa-earth
 	url = https://github.com/pypsa-meets-earth/pypsa-earth
+	branch = main

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -29,7 +29,7 @@ policy_config:
   policy: "H2_export_monthly_constraint" #either "H2_export_yearly_constraint", "H2_export_monthly_constraint", "no_res_matching" # TODO check wether "export" is required here or misleading
   allowed_excess: 1.0 # currently only implemented for the monthly constraint
   reference_case: true
-  
+
 
 clustering_options:
   alternative_clustering: true

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -26,7 +26,8 @@ scenario:
   - "DF"
 
 policy_config:
-  policy: "H2_export_yearly_constraint" #either "H2_export_yearly_constraint", "H2_export_monthly_constraint", "no_res_matching" # TODO check wether "export" is required here or misleading
+  policy: "H2_export_monthly_constraint" #either "H2_export_yearly_constraint", "H2_export_monthly_constraint", "no_res_matching" # TODO check wether "export" is required here or misleading
+  allowed_excess: 3 # currently only implemented for the monthly constraint
 
 clustering_options:
   alternative_clustering: true

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -27,9 +27,9 @@ scenario:
 
 policy_config:
   policy: "H2_export_monthly_constraint" #either "H2_export_yearly_constraint", "H2_export_monthly_constraint", "no_res_matching" # TODO check wether "export" is required here or misleading
-  allowed_excess: 3 # currently only implemented for the monthly constraint
+  allowed_excess: 1.0 # currently only implemented for the monthly constraint
   reference_case: true
-  allowed_excess: 1.0
+  
 
 clustering_options:
   alternative_clustering: true

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -26,7 +26,7 @@ scenario:
   - "DF"
 
 policy_config:
-  policy: "H2_export_yearly_constraint"
+  policy: "H2_export_yearly_constraint" #either "H2_export_yearly_constraint" or "H2_export_monthly_constraint" # TODO check wether "export" is required here or misleading
 
 clustering_options:
   alternative_clustering: true

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -26,7 +26,7 @@ scenario:
   - "DF"
 
 policy_config:
-  policy: "H2_export_yearly_constraint" #either "H2_export_yearly_constraint" or "H2_export_monthly_constraint" # TODO check wether "export" is required here or misleading
+  policy: "H2_export_yearly_constraint" #either "H2_export_yearly_constraint", "H2_export_monthly_constraint", "no_res_matching" # TODO check wether "export" is required here or misleading
 
 clustering_options:
   alternative_clustering: true

--- a/config.pypsa-earth.yaml
+++ b/config.pypsa-earth.yaml
@@ -66,7 +66,7 @@ cluster_options:
     algorithm: kmeans
     feature: solar+onwind-time
     exclude_carriers: []
-  alternative_clustering: True  # "False" use Voronoi shapes, "True" use GADM shapes
+  alternative_clustering: true  # "False" use Voronoi shapes, "True" use GADM shapes
   distribute_cluster: ['load'] # Distributes cluster nodes per country according to ['load'],['pop'] or ['gdp']
   out_logging: true  # When "True", logging is printed to console
   aggregation_strategies:

--- a/config.pypsa-earth.yaml
+++ b/config.pypsa-earth.yaml
@@ -30,10 +30,10 @@ snapshots:
   inclusive: "left" # end is not inclusive
 
 enable:
-  retrieve_databundle: false  #  Recommended 'true', for the first run. Otherwise data might be missing.
-  retrieve_cost_data: false  # true: retrieves cost data from technology data and saves in resources/costs.csv, false: uses cost data in data/costs.csv
-  download_osm_data: false  # If 'true', OpenStreetMap data will be downloaded for the above given countries
-  build_natura_raster: false  # If True, than an exclusion raster will be build
+  retrieve_databundle: true  #  Recommended 'true', for the first run. Otherwise data might be missing.
+  retrieve_cost_data: true  # true: retrieves cost data from technology data and saves in resources/costs.csv, false: uses cost data in data/costs.csv
+  download_osm_data: true  # If 'true', OpenStreetMap data will be downloaded for the above given countries
+  build_natura_raster: true  # If True, than an exclusion raster will be build
   build_cutout: true
   # If "build_cutout" : true, then environmental data is extracted according to `snapshots` date range and `countries`
   # requires cds API key https://cds.climate.copernicus.eu/api-how-to
@@ -66,7 +66,7 @@ cluster_options:
     algorithm: kmeans
     feature: solar+onwind-time
     exclude_carriers: []
-  alternative_clustering: false  # "False" use Voronoi shapes, "True" use GADM shapes
+  alternative_clustering: True  # "False" use Voronoi shapes, "True" use GADM shapes
   distribute_cluster: ['load'] # Distributes cluster nodes per country according to ['load'],['pop'] or ['gdp']
   out_logging: true  # When "True", logging is printed to console
   aggregation_strategies:
@@ -116,8 +116,8 @@ load_options:
 
 electricity:
   voltages: [220., 300., 380.]
-  co2limit: 4.0e+3  # European default, 0.05 * 3.1e9*0.5, needs to be adjusted for Africa
-  co2base: 1.487e+8  # European default, adjustment to Africa necessary
+  co2limit: 40.0e+6  # European default, 0.05 * 3.1e9*0.5, needs to be adjusted for Africa
+  co2base: 40.0e+6  # European default, adjustment to Africa necessary
   agg_p_nom_limits: data/agg_p_nom_minmax.csv
   hvdc_as_lines: true # should HVDC lines be modeled as `Line` or as `Link` component?
 

--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -205,8 +205,6 @@ def create_network_topology(
         topo_reverse.index = topo_reverse.apply(make_index, axis=1)
         topo = pd.concat([topo, topo_reverse])
 
-
-
     return topo
 
 
@@ -504,7 +502,7 @@ def get_GADM_layer(country_list, layer_id, update=False, outlogging=False):
         # in the GADM processing of sub-national zones
         geodf_temp["GADM_ID"] = geodf_temp[f"GID_{code_layer}"]
 
-       # concatenate geodataframes
+        # concatenate geodataframes
         geodf_list = pd.concat([geodf_list, geodf_temp])
 
     geodf_GADM = gpd.GeoDataFrame(pd.concat(geodf_list, ignore_index=True))

--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -203,7 +203,9 @@ def create_network_topology(
         topo_reverse = topo.copy()
         topo_reverse.rename(columns=swap_buses, inplace=True)
         topo_reverse.index = topo_reverse.apply(make_index, axis=1)
-        topo = topo.append(topo_reverse)
+        topo = pd.concat([topo, topo_reverse])
+
+
 
     return topo
 
@@ -502,8 +504,8 @@ def get_GADM_layer(country_list, layer_id, update=False, outlogging=False):
         # in the GADM processing of sub-national zones
         geodf_temp["GADM_ID"] = geodf_temp[f"GID_{code_layer}"]
 
-        # append geodataframes
-        geodf_list.append(geodf_temp)
+       # concatenate geodataframes
+        geodf_list = pd.concat([geodf_list, geodf_temp])
 
     geodf_GADM = gpd.GeoDataFrame(pd.concat(geodf_list, ignore_index=True))
     geodf_GADM.set_crs(geodf_list[0].crs, inplace=True)

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -248,7 +248,7 @@ def monthly_constraints(n):
         columns=electrolysis.columns,
     )
 
-    load = linexpr((-allowed_excess * weightings_electrolysis, electrolysis))
+    load = linexpr((-allowed_excess * weightings_electrolysis, electrolysis)).sum(axis=1)
 
     load = load.groupby(load.index.month).sum()
 
@@ -447,12 +447,12 @@ if __name__ == "__main__":
             simpl="",
             clusters="4",
             ll="c1.0",
-            opts="Co2L1.0",
+            opts="Co2L",
             planning_horizons="2030",
-            sopts="6H",
+            sopts="200H",
             discountrate=0.071,
             demand="DF",
-            h2export=20,
+            h2export=40,
         )
         sets_path_to_root("pypsa-earth-sec")
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -333,8 +333,11 @@ def extra_functionality(n, snapshots):
         logger.info("setting h2 export to monthly greenness constraint")
         monthly_constraints(n)
 
-    else:
+    elif snakemake.config["policy_config"]["policy"] == "no_res_matching":
         logger.info("no valid h2 export constraint set")
+
+    else:
+        logger.info("h2 export constraint is invalid")
 
     if snakemake.config["H2_network"]:
         if snakemake.config["H2_network_limit"]:

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -199,7 +199,9 @@ def H2_export_yearly_constraint(n):
 
     lhs = res
 
-    rhs = h2_export * (1 / 0.7) + load  # 0.7 is approximation of electrloyzer capacity
+    rhs = (
+        h2_export * (1 / 0.7) + load
+    )  # 0.7 is approximation of electrloyzer efficiency # TODO obtain value from network
 
     con = define_constraints(n, lhs, ">=", rhs, "H2ExportConstraint", "RESproduction")
 
@@ -414,14 +416,14 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "solve_network",
             simpl="",
-            clusters="165",
+            clusters="4",
             ll="c1.0",
-            opts="Co2L",
+            opts="Co2L1.0",
             planning_horizons="2030",
-            sopts="168H",
+            sopts="6H",
             discountrate=0.071,
-            demand="AP",
-            h2export=1,
+            demand="DF",
+            h2export=20,
         )
         sets_path_to_root("pypsa-earth-sec")
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -236,7 +236,7 @@ def monthly_constraints(n):
     ]
 
     # allowed_excess = float(policy.replace("monthly","").replace("p","."))
-    allowed_excess = 1
+    allowed_excess = float(snakemake.config["policy_config"]["allowed_excess"])
     # load = linexpr(
     #     (-allowed_excess * n.snapshot_weightings["generators"], electrolysis)
     # )

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -248,7 +248,9 @@ def monthly_constraints(n):
         columns=electrolysis.columns,
     )
 
-    load = linexpr((-allowed_excess * weightings_electrolysis, electrolysis)).sum(axis=1)
+    load = linexpr((-allowed_excess * weightings_electrolysis, electrolysis)).sum(
+        axis=1
+    )
 
     load = load.groupby(load.index.month).sum()
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -358,10 +358,12 @@ def extra_functionality(n, snapshots):
         monthly_constraints(n)
 
     elif snakemake.config["policy_config"]["policy"] == "no_res_matching":
-        logger.info("no valid h2 export constraint set")
+        logger.info("no h2 export constraint set")
 
     else:
-        logger.info("h2 export constraint is invalid")
+        raise ValueError(
+            'H2 export constraint is invalid, check config["policy_config"]["policy"]'
+        )
 
     if snakemake.config["H2_network"]:
         if snakemake.config["H2_network_limit"]:

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -324,8 +324,15 @@ def add_co2_sequestration_limit(n, sns):
 def extra_functionality(n, snapshots):
     add_battery_constraints(n)
     if snakemake.config["policy_config"]["policy"] == "H2_export_yearly_constraint":
-        print("setting h2 export to greenness constraint")
+        logger.info("setting h2 export to yearly greenness constraint")
         H2_export_yearly_constraint(n)
+
+    elif snakemake.config["policy_config"]["policy"] == "H2_export_monthly_constraint":
+        logger.info("setting h2 export to monthly greenness constraint")
+        monthly_constraints(n)
+
+    else:
+        logger.info("no valid h2 export constraint set")
 
     if snakemake.config["H2_network"]:
         if snakemake.config["H2_network_limit"]:

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -29,7 +29,7 @@ clustering_options:
   alternative_clustering: true
 
 policy_config:
-  policy: "H2_export_yearly_constraint" #either "H2_export_yearly_constraint" or "H2_export_monthly_constraint" # TODO check wether "export" is required here or misleading
+  policy: "H2_export_yearly_constraint" #either "H2_export_yearly_constraint", "H2_export_monthly_constraint", "no_res_matching" # TODO check wether "export" is required here or misleading
 
 countries: ['NG', 'BJ']
 H2_network: false

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -29,7 +29,8 @@ clustering_options:
   alternative_clustering: true
 
 policy_config:
-  policy: "H2_export_yearly_constraint" #either "H2_export_yearly_constraint", "H2_export_monthly_constraint", "no_res_matching" # TODO check wether "export" is required here or misleading
+  policy: "H2_export_monthly_constraint" #either "H2_export_yearly_constraint", "H2_export_monthly_constraint", "no_res_matching" # TODO check wether "export" is required here or misleading
+  allowed_excess: 3 # currently only implemented for the monthly constraint
 
 countries: ['NG', 'BJ']
 H2_network: false

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -29,7 +29,7 @@ clustering_options:
   alternative_clustering: true
 
 policy_config:
-  policy: "" #"H2_export_yearly_constraint"
+  policy: "H2_export_yearly_constraint" #either "H2_export_yearly_constraint" or "H2_export_monthly_constraint" # TODO check wether "export" is required here or misleading
 
 countries: ['NG', 'BJ']
 H2_network: false


### PR DESCRIPTION
# Closes #194 

## Changes proposed in this Pull Request
This PR includes the monthly matching constraint of hydrogen

Open Questions:

- Matching for export hydrogen only or export + local hydrogen? -> Just export hydrogen + local AC demand
- The current implementation of annual matching (RES >= H2_export + AC_local) forces the local electricity system to be green as well. This is probably not intended in the first place but we have to be aware of it / fix it

Testing phase:
- run 200H model without matching, annual matching, monthly matching 

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
