### PR TITLE
Include export store options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ The diagram below depicts one representative clustered node showing the combinat
    ```bash
        .../some/path/without/spaces % git clone --recurse-submodules https://github.com/pypsa-meets-earth/pypsa-earth-sec.git
    ```
+   To make sure you run the latest version of the submodule (if desired), run the following command to update the git submodules:
+   ```bash
+       .../some/path/without/spaces % git submodule update
+   ```
 
 2. Move the current directory to the head of the repository.
    ```bash

--- a/Snakefile
+++ b/Snakefile
@@ -132,6 +132,7 @@ rule add_export:
     input:
         overrides="data/override_component_attrs",
         export_ports="data/export_ports.csv",
+        costs=CDIR + "costs_{planning_horizons}.csv",
         network=RDIR
         + "/prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}.nc",
         shapes_path=pypsaearth(

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -43,7 +43,9 @@ hydrogen_underground_storage: false
 
 
 export:
-  h2export: [1, 5] # Yearly export demand in TWh
+    h2export: [1, 5] # Yearly export demand in TWh
+    store: True # [True, False] # specifies wether an export store to balance demand is implemented
+    store_capital_costs: "no_cost" # ["standard_cost", "no_cost"] # specifies the costs of the export store
 
 custom_data:
   renewables: [] # ['csp', 'rooftop-solar', 'solar']

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -43,9 +43,9 @@ hydrogen_underground_storage: false
 
 
 export:
-    h2export: [1, 5] # Yearly export demand in TWh
-    store: True # [True, False] # specifies wether an export store to balance demand is implemented
-    store_capital_costs: "no_cost" # ["standard_cost", "no_cost"] # specifies the costs of the export store
+  h2export: [1, 5]   # Yearly export demand in TWh
+  store: true   # [True, False] # specifies wether an export store to balance demand is implemented
+  store_capital_costs: "no_cost"   # ["standard_cost", "no_cost"] # specifies the costs of the export store
 
 custom_data:
   renewables: [] # ['csp', 'rooftop-solar', 'solar']

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -258,7 +258,7 @@ snapshots:
   # arguments to pd.date_range
   start: "2013-01-01"
   end: "2014-01-01"
-  closed: "left" # end is not inclusive
+  inclusive: "left" # end is not inclusive
 
 # atlite:
 #   cutout: ./cutouts/africa-2013-era5.nc

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -43,9 +43,9 @@ hydrogen_underground_storage: false
 
 
 export:
-  h2export: [1, 5]   # Yearly export demand in TWh
-  store: true   # [True, False] # specifies wether an export store to balance demand is implemented
-  store_capital_costs: "no_cost"   # ["standard_cost", "no_cost"] # specifies the costs of the export store
+  h2export: [120] # Yearly export demand in TWh
+  store: True # [True, False] # specifies wether an export store to balance demand is implemented
+  store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store
 
 custom_data:
   renewables: [] # ['csp', 'rooftop-solar', 'solar']

--- a/config.pypsa-earth.yaml
+++ b/config.pypsa-earth.yaml
@@ -66,7 +66,7 @@ cluster_options:
     algorithm: kmeans
     feature: solar+onwind-time
     exclude_carriers: []
-  alternative_clustering: True  # "False" use Voronoi shapes, "True" use GADM shapes
+  alternative_clustering: true  # "False" use Voronoi shapes, "True" use GADM shapes
   distribute_cluster: ['load'] # Distributes cluster nodes per country according to ['load'],['pop'] or ['gdp']
   out_logging: true  # When "True", logging is printed to console
   aggregation_strategies:

--- a/config.pypsa-earth.yaml
+++ b/config.pypsa-earth.yaml
@@ -22,6 +22,8 @@ enable:
   # requires cds API key https://cds.climate.copernicus.eu/api-how-to
   # More information https://atlite.readthedocs.io/en/latest/introduction.html#datasets
 
+custom_rules: []  # Default empty [] or link to custom rule file e.g. ["my_folder/my_rules.smk"] that add rules to Snakefile
+
 run:
   name: "" # use this to keep track of runs with different settings
   shared_cutouts: true  # set to true to share the default cutout(s) across runs
@@ -120,8 +122,8 @@ load_options:
 electricity:
   base_voltage: 380.
   voltages: [220., 300., 380.]
-  co2limit: 40.0e+6  # European default, 0.05 * 3.1e9*0.5, needs to be adjusted for Africa
-  co2base: 40.0e+6  # European default, adjustment to Africa necessary
+  co2limit: 72.0e+6  # European default, 0.05 * 3.1e9*0.5, needs to be adjusted for Africa
+  co2base: 72.0e+6  # European default, adjustment to Africa necessary
   agg_p_nom_limits: data/agg_p_nom_minmax.csv
   hvdc_as_lines: true # should HVDC lines be modeled as `Line` or as `Link` component?
 

--- a/config.pypsa-earth.yaml
+++ b/config.pypsa-earth.yaml
@@ -30,10 +30,10 @@ snapshots:
   inclusive: "left" # end is not inclusive
 
 enable:
-  retrieve_databundle: false  #  Recommended 'true', for the first run. Otherwise data might be missing.
-  retrieve_cost_data: false  # true: retrieves cost data from technology data and saves in resources/costs.csv, false: uses cost data in data/costs.csv
-  download_osm_data: false  # If 'true', OpenStreetMap data will be downloaded for the above given countries
-  build_natura_raster: false  # If True, than an exclusion raster will be build
+  retrieve_databundle: true  #  Recommended 'true', for the first run. Otherwise data might be missing.
+  retrieve_cost_data: true  # true: retrieves cost data from technology data and saves in resources/costs.csv, false: uses cost data in data/costs.csv
+  download_osm_data: true  # If 'true', OpenStreetMap data will be downloaded for the above given countries
+  build_natura_raster: true  # If True, than an exclusion raster will be build
   build_cutout: true
   # If "build_cutout" : true, then environmental data is extracted according to `snapshots` date range and `countries`
   # requires cds API key https://cds.climate.copernicus.eu/api-how-to
@@ -66,7 +66,7 @@ cluster_options:
     algorithm: kmeans
     feature: solar+onwind-time
     exclude_carriers: []
-  alternative_clustering: false  # "False" use Voronoi shapes, "True" use GADM shapes
+  alternative_clustering: True  # "False" use Voronoi shapes, "True" use GADM shapes
   distribute_cluster: ['load'] # Distributes cluster nodes per country according to ['load'],['pop'] or ['gdp']
   out_logging: true  # When "True", logging is printed to console
   aggregation_strategies:
@@ -116,8 +116,8 @@ load_options:
 
 electricity:
   voltages: [220., 300., 380.]
-  co2limit: 4.0e+3  # European default, 0.05 * 3.1e9*0.5, needs to be adjusted for Africa
-  co2base: 1.487e+8  # European default, adjustment to Africa necessary
+  co2limit: 40.0e+6  # European default, 0.05 * 3.1e9*0.5, needs to be adjusted for Africa
+  co2base: 40.0e+6  # European default, adjustment to Africa necessary
   agg_p_nom_limits: data/agg_p_nom_minmax.csv
   hvdc_as_lines: true # should HVDC lines be modeled as `Line` or as `Link` component?
 

--- a/config.pypsa-earth.yaml
+++ b/config.pypsa-earth.yaml
@@ -1,14 +1,26 @@
-# SPDX-FileCopyrightText: : 2021 The PyPSA-Earth Authors
+# SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
 #
 # SPDX-License-Identifier: CC0-1.0
 
-
-version: 1.0.0
+version: 0.2.1
 tutorial: false
 
 logging:
   level: INFO
   format: "%(levelname)s:%(name)s:%(message)s"
+
+countries: ["MA"]
+# Can be replaced by country ["NG", "BJ"], continent ["Africa"] or user-specific region, see more at https://pypsa-earth.readthedocs.io/en/latest/configuration.html#top-level-configuration
+
+enable:
+  retrieve_databundle: true  #  Recommended 'true', for the first run. Otherwise data might be missing.
+  retrieve_cost_data: true  # true: retrieves cost data from technology data and saves in resources/costs.csv, false: uses cost data in data/costs.csv
+  download_osm_data: true  # If 'true', OpenStreetMap data will be downloaded for the above given countries
+  build_natura_raster: true  # If True, than an exclusion raster will be build
+  build_cutout: true
+  # If "build_cutout" : true, then environmental data is extracted according to `snapshots` date range and `countries`
+  # requires cds API key https://cds.climate.copernicus.eu/api-how-to
+  # More information https://atlite.readthedocs.io/en/latest/introduction.html#datasets
 
 run:
   name: "" # use this to keep track of runs with different settings
@@ -21,23 +33,10 @@ scenario:
   clusters: [10]
   opts: [Co2L1-144H]
 
-countries: ["MA"]
-# Can be replaced by country ["NG", "BJ"], continent ["Africa"] or user-specific region, see more at https://pypsa-earth.readthedocs.io/en/latest/configuration.html#top-level-configuration
-
 snapshots:
   start: "2013-01-01"
   end: "2014-01-01"
   inclusive: "left" # end is not inclusive
-
-enable:
-  retrieve_databundle: true  #  Recommended 'true', for the first run. Otherwise data might be missing.
-  retrieve_cost_data: true  # true: retrieves cost data from technology data and saves in resources/costs.csv, false: uses cost data in data/costs.csv
-  download_osm_data: true  # If 'true', OpenStreetMap data will be downloaded for the above given countries
-  build_natura_raster: true  # If True, than an exclusion raster will be build
-  build_cutout: true
-  # If "build_cutout" : true, then environmental data is extracted according to `snapshots` date range and `countries`
-  # requires cds API key https://cds.climate.copernicus.eu/api-how-to
-  # More information https://atlite.readthedocs.io/en/latest/introduction.html#datasets
 
 # definition of the Coordinate Reference Systems
 crs:
@@ -56,12 +55,14 @@ augmented_line_connection:
 
 cluster_options:
   simplify_network:
-    to_substations: false   # network is simplified to nodes with positive or negative power injection (i.e. substations or offwind connections)
-    algorithm: kmeans   # choose from: [hac, kmeans]
-    feature: solar+onwind-time   # only for hac. choose from: [solar+onwind-time, solar+onwind-cap, solar-time, solar-cap, solar+offwind-cap] etc.
+    to_substations: false # network is simplified to nodes with positive or negative power injection (i.e. substations or offwind connections)
+    algorithm: kmeans # choose from: [hac, kmeans]
+    feature: solar+onwind-time # only for hac. choose from: [solar+onwind-time, solar+onwind-cap, solar-time, solar-cap, solar+offwind-cap] etc.
     exclude_carriers: []
     remove_stubs: true
     remove_stubs_across_borders: true
+    p_threshold_drop_isolated: 20 # [MW] isolated buses are being discarded if bus mean power is below the specified threshold
+    p_threshold_merge_isolated: 300 # [MW] isolated buses are being merged into a single isolated bus if bus mean power is below the specified threshold
   cluster_network:
     algorithm: kmeans
     feature: solar+onwind-time
@@ -91,6 +92,7 @@ build_shape_options:
   worldpop_method: "standard"  # "standard" pulls from web 1kmx1km raster, "api" pulls from API 100mx100m raster, false (not "false") no pop addition to shape which is useful when generating only cutout
   gdp_method: "standard"  # "standard" pulls from web 1x1km raster, false (not "false") no gdp addition to shape which useful when generating only cutout
   contended_flag: "set_by_country" # "set_by_country" assigns the contended areas to the countries according to the GADM database, "drop" drops these contended areas from the model
+
 clean_osm_data_options:  # osm = OpenStreetMap
   names_by_shapes: true  # Set the country name based on the extended country shapes
   threshold_voltage: 35000  # [V] assets below that voltage threshold will not be used (cable, line, generator, etc.)
@@ -100,9 +102,10 @@ clean_osm_data_options:  # osm = OpenStreetMap
 
 build_osm_network:  # Options of the build_osm_network script; osm = OpenStreetMap
   group_close_buses: true  # When "True", close buses are merged and guarantee the voltage matching among line endings
-  group_tolerance_buses: 500  # [m] (default 500) Tolerance in meters of the close buses to merge
+  group_tolerance_buses: 5000  # [m] (default 5000) Tolerance in meters of the close buses to merge
   split_overpassing_lines: true  # When True, lines overpassing buses are splitted and connected to the bueses
   overpassing_lines_tolerance: 1  # [m] (default 1) Tolerance to identify lines overpassing buses
+  force_ac: false  # When true, it forces all components (lines and substation) to be AC-only. To be used if DC assets create problem.
 
 base_network:
   min_voltage_substation_offshore: 35000  # [V] minimum voltage of the offshore substations
@@ -115,6 +118,7 @@ load_options:
   scale: 1  # scales all load time-series, i.e. 2 = doubles load
 
 electricity:
+  base_voltage: 380.
   voltages: [220., 300., 380.]
   co2limit: 40.0e+6  # European default, 0.05 * 3.1e9*0.5, needs to be adjusted for Africa
   co2base: 40.0e+6  # European default, adjustment to Africa necessary
@@ -138,7 +142,7 @@ electricity:
     Link: []  # H2 pipeline
 
   powerplants_filter: (DateOut >= 2022 or DateOut != DateOut)
-  custom_powerplants: false
+  custom_powerplants: false  #  "false" use only powerplantmatching (ppm) data, "merge" combines ppm and custom powerplants, "replace" use only custom powerplants
 
   conventional_carriers: [nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass]
   renewable_carriers: [solar, onwind, offwind-ac, offwind-dc, hydro]
@@ -168,7 +172,6 @@ lines:
 links:
   p_max_pu: 1.0
   p_nom_max: .inf
-  include_tyndp: true
   under_construction: "zero" # 'zero': set capacity to zero, 'remove': remove, 'keep': with full capacity
 
 transformers:
@@ -294,10 +297,11 @@ renewable:
       method: hydro_capacities  # 'hydro_capacities' to rescale country hydro production by using hydro_capacities, 'eia' to rescale by eia data, false for no rescaling
       year: 2013  # (optional) year of statistics used to rescale the runoff time series. When not provided, the weather year of the snapshots is used
     multiplier: 1.1  # multiplier applied after the normalization of the hydro production; default 1.0
-# TODO: Needs to be adjusted for Africa
+
+# TODO: Needs to be adjusted for Africa.
+# Costs Configuration (Do not remove, needed for Sphynx documentation).
 costs:
   year: 2030
-
   version: v0.5.0
   rooftop_share: 0.14  # based on the potentials, assuming  (0.1 kW/m2 and 10 m2/person)
   USD2013_to_EUR2013: 0.7532 # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html
@@ -309,7 +313,7 @@ costs:
     investment: 0
     lifetime: 25
     CO2 intensity: 0
-    discount rate: 0.07
+    discount rate: 0.15
   marginal_cost: # EUR/MWh
     solar: 0.01
     onwind: 0.015

--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -94,7 +94,7 @@ def add_export(n, hydrogen_buses_ports, export_h2):
             capital_cost = 0
         elif snakemake.config["export"]["store_capital_costs"] == "standard_costs":
             capital_cost = costs.at[
-                "hydrogen storage tank type 1 including compressor", "fixed"
+                "hydrogen storage tank incl. compressor", "fixed"
             ]
         else:
             logger.error(
@@ -135,14 +135,14 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "add_export",
             simpl="",
-            clusters="16",
+            clusters="10",
             ll="c1.0",
-            opts="Co2L",
+            opts="Co2L0.10",
             planning_horizons="2030",
-            sopts="144H",
-            discountrate=0.071,
+            sopts="6H",
+            discountrate="0.071",
             demand="DF",
-            h2export=[0],
+            h2export="120",
         )
         sets_path_to_root("pypsa-earth-sec")
 

--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -107,9 +107,10 @@ def add_export(n, hydrogen_buses_ports, export_h2):
             bus="H2 export bus",
             e_nom_extendable=True,
             carrier="H2",
-            e_initial=0,
+            e_initial=0, # actually not required, since e_cyclic=True
             marginal_cost=0,
             capital_cost=capital_cost,
+            e_cyclic=True,
         )
 
     elif snakemake.config["export"]["store"] == False:

--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -89,16 +89,17 @@ def add_export(n, hydrogen_buses_ports, export_h2):
 
     # add store depending on config settings
 
-
-
     if snakemake.config["export"]["store"] == True:
-
         if snakemake.config["export"]["store_capital_costs"] == "no_costs":
             capital_cost = 0
         elif snakemake.config["export"]["store_capital_costs"] == "standard_costs":
-            capital_cost = costs.at["hydrogen storage tank type 1 including compressor", "fixed"]
+            capital_cost = costs.at[
+                "hydrogen storage tank type 1 including compressor", "fixed"
+            ]
         else:
-            logger.error(f"Value {snakemake.config['export']['store_capital_costs']} for ['export']['store_capital_costs'] is not valid")
+            logger.error(
+                f"Value {snakemake.config['export']['store_capital_costs']} for ['export']['store_capital_costs'] is not valid"
+            )
 
         n.add(
             "Store",

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -379,7 +379,7 @@ def plot_transmission_topology(network):
     n.links.bus0 = n.links.bus0.str.replace(" H2", "")
     n.links.bus1 = n.links.bus1.str.replace(" H2", "")
 
-    n.lines.append(DC_lines[["bus0", "bus1"]])
+    n.lines = pd.concat([n.lines, DC_lines[["bus0", "bus1"]]])
 
     n.madd("Line", names=DC_lines.index, bus0=DC_lines.bus0, bus1=DC_lines.bus1)
 

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -42,9 +42,9 @@ hydrogen_underground_storage: false
 
 
 export:
-    h2export: [1, 5] # Yearly export demand in TWh
-    store: True # [True, False] # specifies wether an export store to balance demand is implemented
-    store_capital_costs: "no_cost" # ["standard_cost", "no_cost"] # specifies the costs of the export store
+  h2export: [1, 5]   # Yearly export demand in TWh
+  store: true   # [True, False] # specifies wether an export store to balance demand is implemented
+  store_capital_costs: "no_cost"   # ["standard_cost", "no_cost"] # specifies the costs of the export store
 
 custom_data:
   renewables: [] # ['csp', 'rooftop-solar', 'solar']

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -42,9 +42,9 @@ hydrogen_underground_storage: false
 
 
 export:
-  h2export: [1, 5]   # Yearly export demand in TWh
-  store: true   # [True, False] # specifies wether an export store to balance demand is implemented
-  store_capital_costs: "no_cost"   # ["standard_cost", "no_cost"] # specifies the costs of the export store
+  h2export: [120] # Yearly export demand in TWh
+  store: True # [True, False] # specifies wether an export store to balance demand is implemented
+  store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store
 
 custom_data:
   renewables: [] # ['csp', 'rooftop-solar', 'solar']

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -42,7 +42,9 @@ hydrogen_underground_storage: false
 
 
 export:
-  h2export: [1, 5] # Yearly export demand in TWh
+    h2export: [1, 5] # Yearly export demand in TWh
+    store: True # [True, False] # specifies wether an export store to balance demand is implemented
+    store_capital_costs: "no_cost" # ["standard_cost", "no_cost"] # specifies the costs of the export store
 
 custom_data:
   renewables: [] # ['csp', 'rooftop-solar', 'solar']


### PR DESCRIPTION
# Closes #156 

Despite tackling #156 (which has been tested successfully), this PR includes the option to add costs to the "dummy" export store.

## Changes proposed in this Pull Request
This PR includes more options to configure the export store. System effects of different settings are currently investigated.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
