### PR TITLE
Functional model for Brazil in 2030

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -102,6 +102,7 @@ rule prepare_sector_network:
         shapes_path=pypsaearth(
             "resources/bus_regions/regions_onshore_elec_s{simpl}_{clusters}.geojson"
         ),
+        pipelines="resources/custom_data/pipelines.csv",
     output:
         RDIR
         + "/prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}.nc",

--- a/Snakefile
+++ b/Snakefile
@@ -512,10 +512,10 @@ if config["custom_data"].get("industry_demand", False) == True:
             ),
             clustered_pop_layout="resources/population_shares/pop_layout_elec_s{simpl}_{clusters}.csv",
             industrial_database="resources/custom_data/industrial_database.csv",
-            #shapes_path=pypsaearth("resources/bus_regions/regions_onshore_elec_s{simpl}_{clusters}.geojson")
-            shapes_path="../pypsa-earth/resources/shapes/MAR2.geojson",
+            shapes_path=pypsaearth("resources/bus_regions/regions_onshore_elec_s{simpl}_{clusters}.geojson")
+            #shapes_path="../pypsa-earth/resources/shapes/MAR2.geojson",
         output:
-            industrial_distribution_key="resources/industry/industrial_distribution_key_elec_s{simpl}_{clusters}.csv",
+            industrial_distribution_key="resources/demand/industrial_distribution_key_elec_s{simpl}_{clusters}.csv",
         threads: 1
         resources:
             mem_mb=1000,

--- a/config.pypsa-earth.yaml
+++ b/config.pypsa-earth.yaml
@@ -103,6 +103,7 @@ build_osm_network:  # Options of the build_osm_network script; osm = OpenStreetM
   group_tolerance_buses: 500  # [m] (default 500) Tolerance in meters of the close buses to merge
   split_overpassing_lines: true  # When True, lines overpassing buses are splitted and connected to the bueses
   overpassing_lines_tolerance: 1  # [m] (default 1) Tolerance to identify lines overpassing buses
+  force_ac: true  # When true, it forces all components (lines and substation) to be AC-only. To be used if DC assets create problem.
 
 base_network:
   min_voltage_substation_offshore: 35000  # [V] minimum voltage of the offshore substations
@@ -116,8 +117,8 @@ load_options:
 
 electricity:
   voltages: [220., 300., 380.]
-  co2limit: 4.0e+3  # European default, 0.05 * 3.1e9*0.5, needs to be adjusted for Africa
-  co2base: 1.487e+8  # European default, adjustment to Africa necessary
+  co2limit: 4.0e+10  # European default, 0.05 * 3.1e9*0.5, needs to be adjusted for Africa
+  co2base: 4.0e+10 #1.487e+8  # European default, adjustment to Africa necessary
   agg_p_nom_limits: data/agg_p_nom_minmax.csv
   hvdc_as_lines: true # should HVDC lines be modeled as `Line` or as `Link` component?
 

--- a/config.pypsa-earth.yaml
+++ b/config.pypsa-earth.yaml
@@ -18,10 +18,10 @@ run:
 scenario:
   simpl: ['']
   ll: ['1.0']
-  clusters: [10]
+  clusters: [27]
   opts: [Co2L1-144H]
 
-countries: ["MA"]
+countries: ["BR"]
 # Can be replaced by country ["NG", "BJ"], continent ["Africa"] or user-specific region, see more at https://pypsa-earth.readthedocs.io/en/latest/configuration.html#top-level-configuration
 
 snapshots:
@@ -60,13 +60,13 @@ cluster_options:
     algorithm: kmeans   # choose from: [hac, kmeans]
     feature: solar+onwind-time   # only for hac. choose from: [solar+onwind-time, solar+onwind-cap, solar-time, solar-cap, solar+offwind-cap] etc.
     exclude_carriers: []
-    remove_stubs: true
+    remove_stubs: false
     remove_stubs_across_borders: true
   cluster_network:
     algorithm: kmeans
     feature: solar+onwind-time
     exclude_carriers: []
-  alternative_clustering: false  # "False" use Voronoi shapes, "True" use GADM shapes
+  alternative_clustering: true  # "False" use Voronoi shapes, "True" use GADM shapes
   distribute_cluster: ['load'] # Distributes cluster nodes per country according to ['load'],['pop'] or ['gdp']
   out_logging: true  # When "True", logging is printed to console
   aggregation_strategies:
@@ -82,7 +82,7 @@ cluster_options:
       efficiency: mean
 
 build_shape_options:
-  gadm_layer_id: 2  # GADM level area used for the gadm_shapes. Codes are country-dependent but roughly: 0: country, 1: region/county-like, 2: municipality-like
+  gadm_layer_id: 1  # GADM level area used for the gadm_shapes. Codes are country-dependent but roughly: 0: country, 1: region/county-like, 2: municipality-like
   update_file: false  # When true, all the input files are downloaded again and replace the existing files
   out_logging: true  # When true, logging is printed to console
   year: 2020  # reference year used to derive shapes, info on population and info on GDP

--- a/scripts/build_industrial_distribution_key.py
+++ b/scripts/build_industrial_distribution_key.py
@@ -47,7 +47,7 @@ def build_nodal_distribution_key(
     keys = pd.DataFrame(index=regions.name, columns=technology, dtype=float)
 
     pop = pd.read_csv(snakemake.input.clustered_pop_layout, index_col=0)
-
+    #pop.index = pop.reset_index().name.apply(lambda i: three_2_two_digits_country(i[:3]) + i[3:]) # TODO traceback three-letter region codes in pypsa-earth 
     # pop["country"] = pop.index.str[:2]
     keys["population"] = pop["total"].values / pop["total"].sum()
 
@@ -86,7 +86,7 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "build_industrial_distribution_key",
             simpl="",
-            clusters=10,
+            clusters=4,
             demand="DF",
             planning_horizons=2030,
         )

--- a/scripts/build_industry_demand.py
+++ b/scripts/build_industry_demand.py
@@ -49,9 +49,9 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "build_industry_demand",
             simpl="",
-            clusters=4,
+            clusters=9,
             planning_horizons=2030,
-            demand="DF",
+            demand="AP",
         )
 
         sets_path_to_root("pypsa-earth-sec")
@@ -62,8 +62,8 @@ if __name__ == "__main__":
         prod_tom_path, header=0, index_col=0, keep_default_na=False
     )
 
-    if snakemake.config["custom_data"]["industry_demand"]:
-        production_tom.drop("Industry Machinery", axis=1, inplace=True)
+    # if snakemake.config["custom_data"]["industry_demand"]:
+    #     production_tom.drop("Industry Machinery", axis=1, inplace=True)
 
     # to_drop=production_tom.sum()[production_tom.sum()==0].index
     # production_tom.drop(to_drop, axis=1, inplace=True)

--- a/scripts/build_industry_demand.py
+++ b/scripts/build_industry_demand.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "build_industry_demand",
             simpl="",
-            clusters=10,
+            clusters=4,
             planning_horizons=2030,
             demand="DF",
         )

--- a/scripts/build_industry_demand.py
+++ b/scripts/build_industry_demand.py
@@ -49,9 +49,9 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "build_industry_demand",
             simpl="",
-            clusters=9,
+            clusters=30,
             planning_horizons=2030,
-            demand="AP",
+            demand="NZ",
         )
 
         sets_path_to_root("pypsa-earth-sec")
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     # Transfromation key to map the material demand to the corresponding carrier demand
     industry_sector_ratios = pd.read_csv(
         snakemake.input.industry_sector_ratios, index_col=0
-    )
+    ).fillna(0)
 
     if snakemake.config["custom_data"]["industry_demand"]:
         industry_sector_ratios.drop(

--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -203,7 +203,7 @@ def create_network_topology(
         topo_reverse = topo.copy()
         topo_reverse.rename(columns=swap_buses, inplace=True)
         topo_reverse.index = topo_reverse.apply(make_index, axis=1)
-        topo = topo.append(topo_reverse)
+        topo = pd.concat([topo, topo_reverse])
 
     return topo
 
@@ -502,8 +502,8 @@ def get_GADM_layer(country_list, layer_id, update=False, outlogging=False):
         # in the GADM processing of sub-national zones
         geodf_temp["GADM_ID"] = geodf_temp[f"GID_{code_layer}"]
 
-        # append geodataframes
-        geodf_list.append(geodf_temp)
+        # concatenate geodataframes
+        geodf_list = pd.concat([geodf_list, geodf_temp])
 
     geodf_GADM = gpd.GeoDataFrame(pd.concat(geodf_list, ignore_index=True))
     geodf_GADM.set_crs(geodf_list[0].crs, inplace=True)

--- a/scripts/override_respot.py
+++ b/scripts/override_respot.py
@@ -30,10 +30,10 @@ def override_values(tech, year, dr):
 
     custom_res["Generator"] = custom_res["Generator"].apply(lambda x: x + " " + tech)
     custom_res = custom_res.set_index("Generator")
+    to_drop = n.generators[n.generators.carrier == tech]
 
     if tech.replace("-", " ") in n.generators.carrier.unique():
-        to_drop = n.generators[n.generators.carrier == tech].index
-        n.mremove("Generator", to_drop)
+        n.mremove("Generator", to_drop.index)
 
     if snakemake.wildcards["planning_horizons"] == 2050:
         directory = "results/" + snakemake.config.run.replace("2050", "2030")
@@ -45,7 +45,10 @@ def override_values(tech, year, dr):
         existing_res = df.loc[tech]
         existing_res.index = existing_res.index.str.apply(lambda x: x + tech)
     else:
-        existing_res = custom_res["installedcapacity"].values
+        if len(to_drop) > 0:
+            existing_res = to_drop.p_nom_min.values #custom_res["installedcapacity"].values
+        else:
+            existing_res = custom_res["installedcapacity"].values
 
     n.madd(
         "Generator",
@@ -61,6 +64,7 @@ def override_values(tech, year, dr):
         efficiency=1.0,
         p_max_pu=custom_res_t,
         lifetime=custom_res["lifetime"][0],
+        p_nom=existing_res,
         p_nom_min=existing_res,
     )
 
@@ -72,13 +76,13 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "override_respot",
             simpl="",
-            clusters="16",
+            clusters="32",
             ll="c1.0",
             opts="Co2L",
             planning_horizons="2030",
             sopts="3H",
-            demand="AP",
-            discountrate=0.071,
+            demand="BS",
+            discountrate=0.175,
         )
         sets_path_to_root("pypsa-earth-sec")
 
@@ -97,6 +101,7 @@ if __name__ == "__main__":
             m = n.copy()
 
             for tech in techs:
+                print(tech)
                 override_values(tech, year, dr)
 
         else:

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -768,17 +768,19 @@ nice_names_n = {
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from helpers import mock_snakemake
+        import os
 
+        os.chdir(os.path.dirname(os.path.abspath(__file__)))
         snakemake = mock_snakemake(
             "plot_network",
             simpl="",
-            clusters="23",
+            clusters="8",
             ll="c1.0",
             opts="Co2L",
             planning_horizons="2030",
             sopts="144H",
             discountrate=0.071,
-            demand="NZ",
+            demand="BS",
         )
 
     n = pypsa.Network(snakemake.input.network)

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -3,6 +3,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import os
 
 plt.style.use("ggplot")
 
@@ -284,6 +285,7 @@ def plot_balances():
         if df.empty:
             continue
 
+        df.index = df.index.str.strip()
         new_index = preferred_order.intersection(df.index).append(
             df.index.difference(preferred_order)
         )
@@ -528,6 +530,7 @@ if __name__ == "__main__":
     if "snakemake" not in globals():
         from helpers import mock_snakemake
 
+        os.chdir(os.path.dirname(os.path.abspath(__file__)))
         snakemake = mock_snakemake("plot_summary")
 
     n_header = 7  # Header lines in the csv files

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2142,7 +2142,7 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "prepare_sector_network",
             simpl="",
-            clusters="10",
+            clusters="4",
             ll="c1.0",
             opts="Co2L",
             planning_horizons="2030",
@@ -2250,12 +2250,12 @@ if __name__ == "__main__":
     # Load industry demand data
     industrial_demand = pd.read_csv(snakemake.input.industrial_demand)  # * 1e6
     print(industrial_demand)
-    if (
-        len(industrial_demand["TWh/a (MtCO2/a)"][0]) > 6
-    ):  # TODO do it nicely, this is done to catch the custom gadm
-        industrial_demand["TWh/a (MtCO2/a)"] = industrial_demand[
-            "TWh/a (MtCO2/a)"
-        ].apply(lambda cocode: two_2_three_digits_country(cocode[:2]) + cocode[2:])
+    # if (
+    #     len(industrial_demand["TWh/a (MtCO2/a)"][0]) > 6
+    # ):  # TODO do it nicely, this is done to catch the custom gadm
+    #     industrial_demand["TWh/a (MtCO2/a)"] = industrial_demand[
+    #         "TWh/a (MtCO2/a)"
+    #     ].apply(lambda cocode: two_2_three_digits_country(cocode[:2]) + cocode[2:])
 
     industrial_demand.set_index("TWh/a (MtCO2/a)", inplace=True)
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -320,10 +320,20 @@ def add_hydrogen(n, costs):
     if snakemake.config["custom_data"]["gas_grid"]:
         h2_links = pd.read_csv(snakemake.input.pipelines)
 
-        #Create index column
+        #Order buses to detect equal pairs for bidirectional pipelines
         buses_ordered = h2_links.apply(lambda p: sorted([p.bus0, p.bus1]), axis=1)
+
+        #Appending string for carrier specification '_AC'
         h2_links['bus0'] = buses_ordered.str[0] + '_AC'
         h2_links['bus1'] = buses_ordered.str[1] + '_AC'
+
+        #Conversion of GADM id to from 3 to 2-digit
+        h2_links['bus0'] = h2_links['bus0'].str.split('.').apply(
+            lambda id: three_2_two_digits_country(id[0]) + "." + id[1])
+        h2_links['bus1'] = h2_links['bus1'].str.split('.').apply(
+            lambda id: three_2_two_digits_country(id[0]) + "." + id[1])
+
+        #Create index column
         h2_links['buses_idx'] = 'H2 pipeline ' + h2_links['bus0'] + ' -> ' + h2_links['bus1']
 
         #Aggregate pipelines applying mean on length and sum on capacities
@@ -2160,11 +2170,11 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "prepare_sector_network",
             simpl="",
-            clusters="20",
+            clusters="22",
             ll="c1.0",
             opts="Co2L",
             planning_horizons="2030",
-            sopts="24H",
+            sopts="3H",
             discountrate="0.071",
             demand="AP",
         )

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -29,7 +29,9 @@ clustering_options:
   alternative_clustering: true
 
 policy_config:
-  policy: "" #"H2_export_yearly_constraint"
+  policy: "H2_export_yearly_constraint" #either "H2_export_yearly_constraint", "H2_export_monthly_constraint", "no_res_matching" # TODO check wether "export" is required here or misleading
+  reference_case: false
+  allowed_excess: 1.0
 
 countries: ['NG', 'BJ']
 H2_network: false


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

This PR includes many small adaptations to the workflow which make it functional for Brazil in 2030. Many adjustments have not been implemented in a clean way and make extensive use of line comments. The adaptations which are found to be generally useful will be implementedin a cleaner way at a later point.
 
- Addition of custom gas grid
- Adaptation to the override_respot.py, in order to transfer existing capacities (p_nom) from pypsa-earth generator components
- Update of pypsa-earth emission constraint avoiding double counting of gas generators
- Adjustments of the add_shipping and add_aviation functions in prepare_sector_network, in order to avoid dropping entities in regions with more than one entity
- Omission of CC technologies
- Addition of monthly matching constraint, which includes run-of-river plants among the allowed renewable technologies for provision of electrolyzer input

## Checklist

- [ x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
