### PR TITLE
fix: Avoid double CO2 accounting

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -130,7 +130,7 @@ def add_oil(n, costs):
 
     # Set the "co2_emissions" of the carrier "oil" to 0, because the emissions of oil usage taken from the spatial.oil.nodes are accounted seperately (directly linked to the co2 atmosphere bus). Setting the carrier to 0 here avoids double counting. Be aware to link oil emissions to the co2 atmosphere bus.
     n.carriers.loc["oil", "co2_emissions"] = 0
-    logger.info("co2_emissions of oil set to 0 for testing")
+    print("co2_emissions of oil set to 0 for testing") # TODO add logger.info
 
     n.madd(
         "Bus",

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -128,6 +128,10 @@ def add_oil(n, costs):
     if "oil" not in n.carriers.index:
         n.add("Carrier", "oil")
 
+    # Set the "co2_emissions" of the carrier "oil" to 0, because the emissions of oil usage taken from the spatial.oil.nodes are accounted seperately (directly linked to the co2 atmosphere bus). Setting the carrier to 0 here avoids double counting. Be aware to link oil emissions to the co2 atmosphere bus.
+    n.carriers.loc["oil", "co2_emissions"] = 0
+    logger.info("co2_emissions of oil set to 0 for testing")
+
     n.madd(
         "Bus",
         spatial.oil.nodes,


### PR DESCRIPTION
# Closes #204 
See #204 for details.

This implementation makes #174 and #201 (alternative co2 constraint implementations) unnecessary.

## Changes proposed in this Pull Request
Set the co2_emissions of the carrier `oil` to zero. 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
