### PR TITLE
Organize green h2

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -5,7 +5,7 @@ results_dir: results/
 summary_dir: results/
 costs_dir: data/ #TODO change to the equivalent of technology data
 
-run: runname
+run: test_h2_cons_yearly
 
 foresight: overnight
 

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -26,9 +26,12 @@ scenario:
   - "DF"
 
 policy_config:
-  policy: "H2_export_monthly_constraint" #either "H2_export_yearly_constraint", "H2_export_monthly_constraint", "no_res_matching" # TODO check wether "export" is required here or misleading
-  allowed_excess: 1.0 # currently only implemented for the monthly constraint
-  reference_case: true
+  policy: "H2_export_yearly_constraint" #either "H2_export_yearly_constraint", "H2_export_monthly_constraint", "no_res_matching"
+  monthly: # Specify attributes for the monthly constraint
+    allowed_excess: 1.0
+    reference_case: false # RE electricity is equal to the amount required for additional hydrogen export compared to the 0 export case ("reference_case")
+  yearly: # Specify attributes for the yearly constraint
+    re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
 
 
 clustering_options:

--- a/config.pypsa-earth.yaml
+++ b/config.pypsa-earth.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-version: 0.2.1
+version: 0.2.2
 tutorial: false
 
 logging:

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -199,7 +199,7 @@ def H2_export_yearly_constraint(n):
 
     lhs = res
 
-    include_country_load = snakemake.config["policy_config"]["yealy"][
+    include_country_load = snakemake.config["policy_config"]["yearly"][
         "include_country_load"
     ]
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -478,15 +478,16 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "solve_network",
             simpl="",
-            clusters="26",
+            clusters="10",
             ll="c1.0",
-            opts="Co2L",
+            opts="Co2L0.60",
             planning_horizons="2030",
-            sopts="144H",
-            discountrate=0.071,
+            sopts="300H",
+            discountrate=0.15,
             demand="DF",
-            h2export="5",
+            h2export="60",
         )
+
         sets_path_to_root("pypsa-earth-sec")
 
     logging.basicConfig(
@@ -513,6 +514,7 @@ if __name__ == "__main__":
         if (
             snakemake.config["policy_config"]["monthly"]["reference_case"]
             and eval(snakemake.wildcards["h2export"]) != 0
+            and snakemake.config["policy_config"]["policy"] == "H2_export_monthly_constraint"
         ):
             n_ref_path = snakemake.output[0].replace(
                 snakemake.output[0].split("_")[-1], "0export.nc"

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -514,7 +514,8 @@ if __name__ == "__main__":
         if (
             snakemake.config["policy_config"]["monthly"]["reference_case"]
             and eval(snakemake.wildcards["h2export"]) != 0
-            and snakemake.config["policy_config"]["policy"] == "H2_export_monthly_constraint"
+            and snakemake.config["policy_config"]["policy"]
+            == "H2_export_monthly_constraint"
         ):
             n_ref_path = snakemake.output[0].replace(
                 snakemake.output[0].split("_")[-1], "0export.nc"

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -200,7 +200,7 @@ def H2_export_yearly_constraint(n):
     lhs = res
 
     include_country_load = snakemake.config["policy_config"]["yearly"][
-        "include_country_load"
+        "re_country_load"
     ]
 
     if include_country_load:

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -25,15 +25,21 @@ scenario:
   demand:
   - "DF"
 
+
+policy_config:
+  policy: "H2_export_yearly_constraint" #either "H2_export_yearly_constraint", "H2_export_monthly_constraint", "no_res_matching"
+  monthly: # Specify attributes for the monthly constraint
+    allowed_excess: 1.0
+    reference_case: false # RE electricity is equal to the amount required for additional hydrogen export compared to the 0 export case ("reference_case")
+  yearly: # Specify attributes for the yearly constraint
+    re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
+
+
 clustering_options:
   alternative_clustering: true
 
-policy_config:
-  policy: "H2_export_yearly_constraint" #either "H2_export_yearly_constraint", "H2_export_monthly_constraint", "no_res_matching" # TODO check wether "export" is required here or misleading
-  reference_case: false
-  allowed_excess: 1.0
-
 countries: ['NG', 'BJ']
+
 H2_network: false
 H2_network_limit: 2000 #GWkm
 
@@ -469,3 +475,4 @@ plotting:
     solid biomass transport: green
     H2 for industry: "#222222"
     H2 for shipping: "#6495ED"
+    biomass EOP: "green"


### PR DESCRIPTION
## Changes proposed in this Pull Request
Organizes the way we implement different green hydrogen settings. 

Open questions to @hazemakhalek:

- Do we need a `reference_case` for the yearly matching?
- Should we include `re_country_load` in monthly matching?


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
