### PR TITLE
Include simplified shipping export profile

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -139,7 +139,7 @@ rule add_export:
         overrides="data/override_component_attrs",
         export_ports="data/export_ports.csv",
         costs=CDIR + "costs_{planning_horizons}.csv",
-        ship_profile="data/ship_profile_9TWh.csv",  # TODO create rule with {h2export} wildcard
+        ship_profile="resources/ship_profile_{h2export}TWh.csv",
         network=RDIR
         + "/prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}.nc",
         shapes_path=pypsaearth(

--- a/Snakefile
+++ b/Snakefile
@@ -133,6 +133,7 @@ rule add_export:
         overrides="data/override_component_attrs",
         export_ports="data/export_ports.csv",
         costs=CDIR + "costs_{planning_horizons}.csv",
+        ship_profile="data/ship_profile_9TWh.csv", # TODO create rule with {h2export} wildcard
         network=RDIR
         + "/prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}.nc",
         shapes_path=pypsaearth(

--- a/Snakefile
+++ b/Snakefile
@@ -128,6 +128,12 @@ rule prepare_sector_network:
         "scripts/prepare_sector_network.py"
 
 
+rule build_ship_profile:
+    output:
+        ship_profile="resources/ship_profile_{h2export}TWh.csv",
+    script:
+        "scripts/build_ship_profile.py"
+
 rule add_export:
     input:
         overrides="data/override_component_attrs",

--- a/Snakefile
+++ b/Snakefile
@@ -133,7 +133,7 @@ rule add_export:
         overrides="data/override_component_attrs",
         export_ports="data/export_ports.csv",
         costs=CDIR + "costs_{planning_horizons}.csv",
-        ship_profile="data/ship_profile_9TWh.csv", # TODO create rule with {h2export} wildcard
+        ship_profile="data/ship_profile_9TWh.csv",  # TODO create rule with {h2export} wildcard
         network=RDIR
         + "/prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}.nc",
         shapes_path=pypsaearth(

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -50,7 +50,11 @@ export:
   store: true # [True, False] # specifies wether an export store to balance demand is implemented
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank incl. compressor"
   export_profile: "ship" # use "ship" or "constant"
-
+  ship:
+    ship_capacity: 0.4 # TWh # 0.05 TWh for new ones, 0.003 TWh for Susio Frontier, 0.4 TWh according to Hampp2021: "Corresponds to 11360 t H2 (l) with LHV of 33.3333 Mwh/t_H2. Cihlar et al 2020 based on IEA 2019, Table 3-B"
+    travel_time: 288 # hours # From Agadir to Rotterdam and back (12*24)
+    fill_time: 24 # hours, for 48h see Hampp2021
+    unload_time: 24 # hours for 48h see Hampp2021
 
 custom_data:
   renewables: [] # ['csp', 'rooftop-solar', 'solar']

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -49,6 +49,8 @@ export:
   h2export: [120] # Yearly export demand in TWh
   store: true # [True, False] # specifies wether an export store to balance demand is implemented
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank incl. compressor"
+  export_profile: "ship" # use "ship" or "constant"
+
 
 custom_data:
   renewables: [] # ['csp', 'rooftop-solar', 'solar']

--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -57,7 +57,7 @@ def select_ports(n):
     return hydrogen_buses_ports
 
 
-def add_export(n, export_profile):
+def add_export(n, hydrogen_buses_ports, export_profile):
     country_shape = gpd.read_file(snakemake.input["shapes_path"])
     # Find most northwestern point in country shape and get x and y coordinates
     country_shape = country_shape.to_crs("EPSG:4326")
@@ -203,10 +203,10 @@ if __name__ == "__main__":
     )
 
     # get hydrogen export buses/ports
-    # hydrogen_buses_ports = select_ports(n)
+    hydrogen_buses_ports = select_ports(n)
 
     # add export value and components to network
-    add_export(n, export_profile)
+    add_export(n, hydrogen_buses_ports, export_profile)
 
     n.export_to_netcdf(snakemake.output[0])
 

--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -149,10 +149,10 @@ def create_export_profile():
 
         if np.abs(export_profile.sum() - export_h2) > 1:  # Threshold of 1 MWh
             logger.error(
-                f"Sum of ship profile ({export_profile.sum().values[0]/1e6} TWh) does not match export demand ({export_h2} TWh)"
+                f"Sum of ship profile ({export_profile.sum()/1e6} TWh) does not match export demand ({export_h2} TWh)"
             )
             raise ValueError(
-                f"Sum of ship profile ({export_profile.sum().values[0]/1e6} TWh) does not match export demand ({export_h2} TWh)"
+                f"Sum of ship profile ({export_profile.sum()/1e6} TWh) does not match export demand ({export_h2} TWh)"
             )
 
     # Resample to temporal resolution defined in wildcard "sopts" with pandas resample
@@ -160,8 +160,9 @@ def create_export_profile():
     export_profile = export_profile.resample(sopts[0]).mean()
 
     # revise logger msg
+    export_type = snakemake.config["export"]["export_profile"]
     logger.info(
-        f"The yearly export demand is {export_h2/1e6} TWh and resampled to {sopts[0]}"
+        f"The yearly export demand is {export_h2/1e6} TWh, profile generated based on {export_type} method and resampled to {sopts[0]}"
     )
 
     return export_profile

--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -60,7 +60,9 @@ def select_ports(n):
 def add_export(n, hydrogen_buses_ports, export_profile):
     country_shape = gpd.read_file(snakemake.input["shapes_path"])
     # Find most northwestern point in country shape and get x and y coordinates
-    country_shape = country_shape.to_crs("EPSG:4326")
+    country_shape = country_shape.to_crs(
+        "EPSG:3395"
+    )  # Project to Mercator projection (Projected)
 
     # Get coordinates of the most western and northern point of the country and add a buffer of 2 degrees (equiv. to approx 220 km)
     x_export = country_shape.geometry.centroid.x.min() - 2

--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -138,10 +138,10 @@ if __name__ == "__main__":
             ll="c1.0",
             opts="Co2L0.10",
             planning_horizons="2030",
-            sopts="6H",
-            discountrate="0.071",
+            sopts="300H",
+            discountrate="0.15",
             demand="DF",
-            h2export="120",
+            h2export="10",
         )
         sets_path_to_root("pypsa-earth-sec")
 
@@ -155,6 +155,16 @@ if __name__ == "__main__":
     logger.info(
         f"The yearly export demand is {export_h2/1e6} TWh resulting in an hourly average of {export_h2/8760:.2f} MWh"
     )
+
+    # Import hydrogen export ship profile and check if it matches the export demand obtained from the wildcard
+    export_h2_profile = pd.read_csv(snakemake.input.ship_profile, index_col=0)
+    if (export_h2_profile.sum() - export_h2).abs().values > 1:  # Threshold of 1 MWh
+        logger.error(
+            f"Sum of ship profile ({export_h2_profile.sum()}) does not match export demand ({export_h2})"
+        )
+        raise ValueError(
+            f"Sum of ship profile ({export_h2_profile.sum()/1e6} TWh) does not match export demand ({export_h2/1e6} TWh)"
+        )
 
     # Prepare the costs dataframe
     Nyears = n.snapshot_weightings.generators.sum() / 8760

--- a/scripts/build_ship_profile.py
+++ b/scripts/build_ship_profile.py
@@ -42,10 +42,11 @@ def build_ship_profile(export_volume, ship_opts):
     ship = pd.concat(
         [ship] * 1000, ignore_index=True
     )  # extend ship series to above 8760 hours
-    ship = ship[:8760]
 
-    # Add index
+
+    # Add index, cut profile after length of snapshots
     snapshots = pd.date_range(freq="h", **snakemake.config["snapshots"])
+    ship = ship[:len(snapshots)]
     ship.index = snapshots
 
     # Scale ship profile to export_volume
@@ -67,7 +68,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake(
             "build_ship_profile",
-            h2export="0",
+            h2export="120",
         )
         sets_path_to_root("pypsa-earth-sec")
 

--- a/scripts/build_ship_profile.py
+++ b/scripts/build_ship_profile.py
@@ -43,10 +43,9 @@ def build_ship_profile(export_volume, ship_opts):
         [ship] * 1000, ignore_index=True
     )  # extend ship series to above 8760 hours
 
-
     # Add index, cut profile after length of snapshots
     snapshots = pd.date_range(freq="h", **snakemake.config["snapshots"])
-    ship = ship[:len(snapshots)]
+    ship = ship[: len(snapshots)]
     ship.index = snapshots
 
     # Scale ship profile to export_volume
@@ -80,7 +79,11 @@ if __name__ == "__main__":
     if export_volume > 0:
         export_profile = build_ship_profile(export_volume, ship_opts)
     else:
-        export_profile = pd.Series(0, index=pd.date_range(freq="h", **snakemake.config["snapshots"]), name="profile")
+        export_profile = pd.Series(
+            0,
+            index=pd.date_range(freq="h", **snakemake.config["snapshots"]),
+            name="profile",
+        )
 
     # Save export profile
     export_profile.to_csv(snakemake.output.ship_profile)  # , header=False)

--- a/scripts/build_ship_profile.py
+++ b/scripts/build_ship_profile.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+
+import logging
+import os
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+logger = logging.getLogger(__name__)
+
+
+def build_ship_profile(export_volume, ship_opts):
+
+    ship_capacity = ship_opts["ship_capacity"]
+    travel_time = ship_opts["travel_time"]
+    fill_time = ship_opts["fill_time"]
+    unload_time = ship_opts["unload_time"]
+
+
+    # Check profile
+
+    return export_profile
+
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        os.chdir(os.path.dirname(os.path.abspath(__file__)))
+        from helpers import mock_snakemake, sets_path_to_root
+
+        snakemake = mock_snakemake(
+            "build_ship_profile",
+            h2export="9",
+        )
+        sets_path_to_root("pypsa-earth-sec")
+
+    # Get parameters from config and wildcard
+    ship_opts = snakemake.config["export"]["ship"]
+    export_volume = eval(snakemake.wildcards.h2export)
+
+    # Create export profile
+    export_profile = build_ship_profile(export_volume, ship_opts)
+
+    # Save export profile
+    export_profile.to_csv(snakemake.output.ship_profile, header=False)
+
+    logger.info("Ship profile successfully created")

--- a/scripts/build_ship_profile.py
+++ b/scripts/build_ship_profile.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake(
             "build_ship_profile",
-            h2export="15",
+            h2export="0",
         )
         sets_path_to_root("pypsa-earth-sec")
 
@@ -76,7 +76,10 @@ if __name__ == "__main__":
     export_volume = eval(snakemake.wildcards.h2export)
 
     # Create export profile
-    export_profile = build_ship_profile(export_volume, ship_opts)
+    if export_volume > 0:
+        export_profile = build_ship_profile(export_volume, ship_opts)
+    else:
+        export_profile = pd.Series(0, index=pd.date_range(freq="h", **snakemake.config["snapshots"]), name="profile")
 
     # Save export profile
     export_profile.to_csv(snakemake.output.ship_profile)  # , header=False)

--- a/scripts/build_ship_profile.py
+++ b/scripts/build_ship_profile.py
@@ -24,14 +24,17 @@ def build_ship_profile(export_volume, ship_opts):
     full_cycle = fill_time + travel_time + unload_time + pause_time
 
     max_transport = ship_capacity * 8760/(fill_time + travel_time + unload_time)
-    print(f"The maximum transport capacity is {max_transport:.2f} TWh/year")
+    print(f"The maximum transport capacity per ship is {max_transport:.2f} TWh/year")
 
     # throw error if max_transport < export_volume
     if max_transport < export_volume:
-        raise ValueError('Not enough ship capacity to export all hydrogen')
+        ships = np.ceil(export_volume / max_transport)
+        print(f"Number of ships needed to export {export_volume} TWh/year is {ships}")
+        logger.info('Not enough ship capacity to export all hydrogen in one ship. Extending the number of shipts to {}'.format(ships))
     
     # Set fill_time ->  1 and travel_time, unload_time, pause_time -> 0
     ship = pd.Series([1.0] * fill_time + [0.0] * int(travel_time + unload_time + pause_time)) #, index)
+    ship.name = "profile"
     ship = pd.concat([ship]*1000, ignore_index=True) # extend ship series to above 8760 hours
     ship = ship[:8760]
 
@@ -57,7 +60,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake(
             "build_ship_profile",
-            h2export="5",
+            h2export="15",
         )
         sets_path_to_root("pypsa-earth-sec")
 

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -47,6 +47,8 @@ export:
   h2export: [120] # Yearly export demand in TWh
   store: true # [True, False] # specifies wether an export store to balance demand is implemented
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store
+  export_profile: "ship" # use "ship" or "constant"
+
 
 custom_data:
   renewables: [] # ['csp', 'rooftop-solar', 'solar']

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -48,6 +48,11 @@ export:
   store: true # [True, False] # specifies wether an export store to balance demand is implemented
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store
   export_profile: "ship" # use "ship" or "constant"
+  ship:
+    ship_capacity: 0.4 # TWh # 0.05 TWh for new ones, 0.003 TWh for Susio Frontier, 0.4 TWh according to Hampp2021: "Corresponds to 11360 t H2 (l) with LHV of 33.3333 Mwh/t_H2. Cihlar et al 2020 based on IEA 2019, Table 3-B"
+    travel_time: 288 # hours # From Agadir to Rotterdam and back (12*24)
+    fill_time: 24 # hours, for 48h see Hampp2021
+    unload_time: 24 # hours for 48h see Hampp2021
 
 
 custom_data:


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request
Include simplified shipping export profile.
Remaining things to do:

- [x] Solve ship case and plot it
- [x] Solve constant case and plot it 
- [ ] Compare outputs: When is hydrogen exported? See Balances
- [x] Move from 300H to 3H
- [x] Integrate creation of ship profile (open up PR for this task?)
- [ ] Profile begins with loading the ship, what are the system implications?

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
