### PR TITLE
Add Fischer-Tropsch efficiency in capital cost calculation

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -209,7 +209,10 @@ def H2_liquid_fossil_conversions(n, costs):
         bus2=spatial.co2.nodes,
         carrier="Fischer-Tropsch",
         efficiency=costs.at["Fischer-Tropsch", "efficiency"],
-        capital_cost=costs.at["Fischer-Tropsch", "fixed"],
+        capital_cost=costs.at["Fischer-Tropsch", "fixed"]
+        * costs.at[
+            "Fischer-Tropsch", "efficiency"
+        ],  # Use efficiency to convert from EUR/MW_FT/a to EUR/MW_H2/a
         efficiency2=-costs.at["oil", "CO2 intensity"]
         * costs.at["Fischer-Tropsch", "efficiency"],
         p_nom_extendable=True,


### PR DESCRIPTION
## Changes proposed in this Pull Request

Fix `capital_cost` of Fischer-Tropsch. Since the `investment` parameter of technology data relates to `EUR/MW_FT` the efficiency is used to convert from EUR/MW_FT/a to EUR/MW_H2/a (https://github.com/PyPSA/technology-data/blob/8bb05d94ac603c463683b5ae12acf438fb962b4f/outputs/costs_2030.csv#L97).

This is is in line with `PyPSA-Eur`
https://github.com/PyPSA/pypsa-eur/blob/f35ecbe4a01f220210c3a295ca93d805f5633824/scripts/prepare_sector_network.py#L2718C9-L2719C68


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
