### PR TITLE
Add Fischer-Tropsch part load

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -273,7 +273,7 @@ sector:
   space_heat_share: 0.6 # the share of space heating from all heating. Remainder goes to water heating.
   airport_sizing_factor: 3
 
-
+  min_part_load_fischer_tropsch: 0.9
 
   conventional_generation: # generator : carrier
     OCGT: gas

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -213,6 +213,7 @@ def H2_liquid_fossil_conversions(n, costs):
         efficiency2=-costs.at["oil", "CO2 intensity"]
         * costs.at["Fischer-Tropsch", "efficiency"],
         p_nom_extendable=True,
+        p_min_pu=options.get("min_part_load_fischer_tropsch", 0),
         lifetime=costs.at["Fischer-Tropsch", "lifetime"],
     )
 
@@ -2316,13 +2317,13 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "prepare_sector_network",
             simpl="",
-            clusters="14",
+            clusters="4",
             ll="c1.0",
-            opts="Co2L",
+            opts="Co2L0.10",
             planning_horizons="2030",
-            sopts="24H",
+            sopts="6H",
             discountrate="0.071",
-            demand="XX",
+            demand="DF",
         )
 
     # Load population layout

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -277,7 +277,7 @@ sector:
   space_heat_share: 0.6 # the share of space heating from all heating. Remainder goes to water heating.
   airport_sizing_factor: 3
 
-
+  min_part_load_fischer_tropsch: 0.9
 
   conventional_generation: # generator : carrier
     OCGT: gas


### PR DESCRIPTION
## Changes proposed in this Pull Request
Add part load option for Fischer-Tropsch. Previously, there was no part load constraint for Fischer-Tropsch, which is introduced here and adjustable in the config. The implementation is similar to:

https://github.com/PyPSA/pypsa-eur/blob/f35ecbe4a01f220210c3a295ca93d805f5633824/scripts/prepare_sector_network.py#L2722-L2724

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
