### PR TITLE
fix: write nan values when sector data is not given

### DIFF
--- a/scripts/build_base_energy_totals.py
+++ b/scripts/build_base_energy_totals.py
@@ -404,6 +404,4 @@ if __name__ == "__main__":
         calc_sector(sector)
 
     # Export the base energy totals file
-    energy_totals_base.to_csv(
-        snakemake.output.energy_totals_base
-    )
+    energy_totals_base.to_csv(snakemake.output.energy_totals_base)

--- a/scripts/build_base_energy_totals.py
+++ b/scripts/build_base_energy_totals.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import glob
+import logging
 import os
 import sys
-import logging
 from io import BytesIO
 from pathlib import Path
 from urllib.request import urlopen
@@ -42,7 +42,6 @@ def calc_sector(sector):
             ]
 
         if df_sector.empty:
-
             if sector == "consumption by households":
                 energy_totals_base.at[country, "electricity residential"] = np.NaN
                 energy_totals_base.at[country, "residential oil"] = np.NaN
@@ -77,7 +76,9 @@ def calc_sector(sector):
                 energy_totals_base.at[country, "total domestic aviation"] = np.NaN
 
             elif sector == "navigation":
-                energy_totals_base.at[country, "total international navigation"] = np.NaN
+                energy_totals_base.at[
+                    country, "total international navigation"
+                ] = np.NaN
                 energy_totals_base.at[country, "total domestic navigation"] = np.NaN
 
             _logger.warning("No data for" + country + " in the sector " + sector + ".")

--- a/scripts/build_base_energy_totals.py
+++ b/scripts/build_base_energy_totals.py
@@ -2,6 +2,7 @@
 import glob
 import os
 import sys
+import logging
 from io import BytesIO
 from pathlib import Path
 from urllib.request import urlopen
@@ -14,6 +15,8 @@ import pandas as pd
 import py7zr
 import requests
 from helpers import sets_path_to_root, three_2_two_digits_country
+
+_logger = logging.getLogger(__name__)
 
 pd.options.mode.chained_assignment = None
 
@@ -39,7 +42,46 @@ def calc_sector(sector):
             ]
 
         if df_sector.empty:
-            pass
+
+            if sector == "consumption by households":
+                energy_totals_base.at[country, "electricity residential"] = np.NaN
+                energy_totals_base.at[country, "residential oil"] = np.NaN
+                energy_totals_base.at[country, "residential biomass"] = np.NaN
+                energy_totals_base.at[country, "residential gas"] = np.NaN
+                energy_totals_base.at[country, "total residential space"] = np.NaN
+                energy_totals_base.at[country, "total residential water"] = np.NaN
+
+            elif sector == "services":
+                energy_totals_base.at[country, "services electricity"] = np.NaN
+                energy_totals_base.at[country, "services oil"] = np.NaN
+                energy_totals_base.at[country, "services biomass"] = np.NaN
+                energy_totals_base.at[country, "services gas"] = np.NaN
+                energy_totals_base.at[country, "total services space"] = np.NaN
+                energy_totals_base.at[country, "total services water"] = np.NaN
+
+            elif sector == "road":
+                energy_totals_base.at[country, "total road"] = np.NaN
+
+            elif sector == "agriculture":
+                energy_totals_base.at[country, "agriculture electricity"] = np.NaN
+                energy_totals_base.at[country, "agriculture oil"] = np.NaN
+                energy_totals_base.at[country, "agriculture biomass"] = np.NaN
+                # energy_totals_base.at[country, "electricity rail"] = np.NaN
+
+            elif sector == "rail":
+                energy_totals_base.at[country, "total rail"] = np.NaN
+                energy_totals_base.at[country, "electricity rail"] = np.NaN
+
+            elif sector == "aviation":
+                energy_totals_base.at[country, "total international aviation"] = np.NaN
+                energy_totals_base.at[country, "total domestic aviation"] = np.NaN
+
+            elif sector == "navigation":
+                energy_totals_base.at[country, "total international navigation"] = np.NaN
+                energy_totals_base.at[country, "total domestic navigation"] = np.NaN
+
+            _logger.warning("No data for" + country + " in the sector " + sector + ".")
+
         else:
             index_mass = df_sector.loc[
                 df_sector["Unit"] == "Metric tons,  thousand"

--- a/scripts/build_base_energy_totals.py
+++ b/scripts/build_base_energy_totals.py
@@ -81,7 +81,7 @@ def calc_sector(sector):
                 ] = np.NaN
                 energy_totals_base.at[country, "total domestic navigation"] = np.NaN
 
-            _logger.warning("No data for" + country + " in the sector " + sector + ".")
+            _logger.warning("No data for " + country + " in the sector " + sector + ".")
 
         else:
             index_mass = df_sector.loc[
@@ -404,6 +404,6 @@ if __name__ == "__main__":
         calc_sector(sector)
 
     # Export the base energy totals file
-    energy_totals_base.dropna(axis=1, how="all").to_csv(
+    energy_totals_base.to_csv(
         snakemake.output.energy_totals_base
     )

--- a/scripts/prepare_energy_totals.py
+++ b/scripts/prepare_energy_totals.py
@@ -272,6 +272,4 @@ if __name__ == "__main__":
     energy_totals["electricity services space"] = 0
     energy_totals["electricity services water"] = 0
 
-    energy_totals = energy_totals.dropna(axis=1, how="all")
-
     energy_totals.fillna(0).to_csv(snakemake.output.energy_totals)


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request
When no sector data is given for a country, we write nan values into base_energy_totals.csv instead of ignoring it.

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
