### PR TITLE
Fix aluminium production year

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -44,7 +44,7 @@ demand_data:
   base_year: 2019
 
   other_industries: false # Whether or not to include industries that are not specified. some countries have has exageratted numbers, check carefully.
-  aluminium_year: 2018 # Year of the aluminium demand data specified in `data/AL_production.csv`
+  aluminium_year: 2019 # Year of the aluminium demand data specified in `data/AL_production.csv`
 
 
 enable:

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -44,7 +44,7 @@ demand_data:
   base_year: 2019
 
   other_industries: false # Whether or not to include industries that are not specified. some countries have has exageratted numbers, check carefully.
-
+  aluminium_year: 2018 # Year of the aluminium demand data specified in `data/AL_production.csv`
 
 
 enable:

--- a/scripts/build_industry_demand.py
+++ b/scripts/build_industry_demand.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "build_industry_demand",
             simpl="",
-            clusters=4,
+            clusters=10,
             planning_horizons=2030,
             demand="AB",
         )
@@ -164,7 +164,7 @@ if __name__ == "__main__":
     geo_locs = match_technology(geo_locs).loc[countries]
 
     AL = read_csv_nafix("data/AL_production.csv", index_col=0)
-    AL_prod_tom = AL["production[ktons/a]"].loc[countries]
+    AL_prod_tom = AL[AL.Year==snakemake.config["demand_data"]["aluminium_year"]]["production[ktons/a]"].loc[countries]
     AL_emissions = AL_prod_tom * emission_factors["non-ferrous metals"]
 
     Steel_emissions = (

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -45,7 +45,7 @@ demand_data:
   base_year: 2019
 
   other_industries: false # Whether or not to include industries that are not specified. some countries have has exageratted numbers, check carefully.
-  aluminium_year: 2018 # Year of the aluminium demand data specified in `data/AL_production.csv`
+  aluminium_year: 2019 # Year of the aluminium demand data specified in `data/AL_production.csv`
 
 
 enable:

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -45,7 +45,7 @@ demand_data:
   base_year: 2019
 
   other_industries: false # Whether or not to include industries that are not specified. some countries have has exageratted numbers, check carefully.
-
+  aluminium_year: 2018 # Year of the aluminium demand data specified in `data/AL_production.csv`
 
 
 enable:


### PR DESCRIPTION
## Changes proposed in this Pull Request
Previsouly, an error occured if there is more than one year of production specified in `data/AL_production`. This PR solves the issue by providing the selection of a certain year in the config.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
