### PR TITLE
Add Params for Rule add_export.py

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -211,6 +211,15 @@ rule build_ship_profile:
 
 
 rule add_export:
+    params:
+        gadm_level= config["sector"]["gadm_level"],
+        alternative_clustering= config["clustering_options"]["alternative_clustering"],
+        store= config["export"]["store"],
+        store_capital_costs= config["export"]["store_capital_costs"],
+        export_profile= config["export"]["export_profile"],
+        snapshots= config["snapshots"],
+        USD2013_to_EUR2013= config["costs"]["USD2013_to_EUR2013"],
+        lifetime= config["costs"]["lifetime"],
     input:
         overrides="data/override_component_attrs",
         export_ports="data/export_ports.csv",

--- a/Snakefile
+++ b/Snakefile
@@ -218,7 +218,7 @@ rule add_export:
         store_capital_costs=config["export"]["store_capital_costs"],
         export_profile=config["export"]["export_profile"],
         snapshots=config["snapshots"],
-        USD2013_to_EUR2013=config["costs"]["USD2013_to_EUR2013"],
+        USD_to_EUR=config["costs"]["USD2013_to_EUR2013"],
         lifetime=config["costs"]["lifetime"],
     input:
         overrides="data/override_component_attrs",

--- a/Snakefile
+++ b/Snakefile
@@ -212,14 +212,14 @@ rule build_ship_profile:
 
 rule add_export:
     params:
-        gadm_level= config["sector"]["gadm_level"],
-        alternative_clustering= config["clustering_options"]["alternative_clustering"],
-        store= config["export"]["store"],
-        store_capital_costs= config["export"]["store_capital_costs"],
-        export_profile= config["export"]["export_profile"],
-        snapshots= config["snapshots"],
-        USD2013_to_EUR2013= config["costs"]["USD2013_to_EUR2013"],
-        lifetime= config["costs"]["lifetime"],
+        gadm_level=config["sector"]["gadm_level"],
+        alternative_clustering=config["clustering_options"]["alternative_clustering"],
+        store=config["export"]["store"],
+        store_capital_costs=config["export"]["store_capital_costs"],
+        export_profile=config["export"]["export_profile"],
+        snapshots=config["snapshots"],
+        USD2013_to_EUR2013=config["costs"]["USD2013_to_EUR2013"],
+        lifetime=config["costs"]["lifetime"],
     input:
         overrides="data/override_component_attrs",
         export_ports="data/export_ports.csv",

--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -39,7 +39,7 @@ def select_ports(n):
         logger.error(
             "No export ports chosen, please add ports to the file data/export_ports.csv"
         )
-    gadm_level = snakemake.config["sector"]["gadm_level"]
+    gadm_level = snakemake.params.gadm_level
 
     ports["gadm_{}".format(gadm_level)] = ports[["x", "y", "country"]].apply(
         lambda port: locate_bus(
@@ -47,7 +47,7 @@ def select_ports(n):
             port["country"],
             gadm_level,
             snakemake.input["shapes_path"],
-            snakemake.config["clustering_options"]["alternative_clustering"],
+            snakemake.params.alternative_clustering,
         ),
         axis=1,
     )
@@ -96,16 +96,16 @@ def add_export(n, hydrogen_buses_ports, export_profile):
 
     # add store depending on config settings
 
-    if snakemake.config["export"]["store"] == True:
-        if snakemake.config["export"]["store_capital_costs"] == "no_costs":
+    if snakemake.params.store == True:
+        if snakemake.params.store_capital_costs == "no_costs":
             capital_cost = 0
-        elif snakemake.config["export"]["store_capital_costs"] == "standard_costs":
+        elif snakemake.params.store_capital_costs == "standard_costs":
             capital_cost = costs.at[
                 "hydrogen storage tank type 1 including compressor", "fixed"
             ]
         else:
             logger.error(
-                f"Value {snakemake.config['export']['store_capital_costs']} for ['export']['store_capital_costs'] is not valid"
+                f"Value {snakemake.params.store_capital_costs} for ['export']['store_capital_costs'] is not valid"
             )
 
         n.add(
@@ -120,7 +120,7 @@ def add_export(n, hydrogen_buses_ports, export_profile):
             e_cyclic=True,
         )
 
-    elif snakemake.config["export"]["store"] == False:
+    elif snakemake.params.store == False:
         pass
 
     # add load
@@ -140,12 +140,12 @@ def create_export_profile():
 
     export_h2 = eval(snakemake.wildcards["h2export"]) * 1e6  # convert TWh to MWh
 
-    if snakemake.config["export"]["export_profile"] == "constant":
+    if snakemake.params.export_profile == "constant":
         export_profile = export_h2 / 8760
-        snapshots = pd.date_range(freq="h", **snakemake.config["snapshots"])
+        snapshots = pd.date_range(freq="h", **snakemake.params.snapshots)
         export_profile = pd.Series(export_profile, index=snapshots)
 
-    elif snakemake.config["export"]["export_profile"] == "ship":
+    elif snakemake.params.export_profile == "ship":
         # Import hydrogen export ship profile and check if it matches the export demand obtained from the wildcard
         export_profile = pd.read_csv(snakemake.input.ship_profile, index_col=0)
         export_profile.index = pd.to_datetime(export_profile.index)
@@ -166,7 +166,7 @@ def create_export_profile():
     export_profile = export_profile.resample(sopts[0]).mean()
 
     # revise logger msg
-    export_type = snakemake.config["export"]["export_profile"]
+    export_type = snakemake.params.export_profile
     logger.info(
         f"The yearly export demand is {export_h2/1e6} TWh, profile generated based on {export_type} method and resampled to {sopts[0]}"
     )
@@ -205,10 +205,10 @@ if __name__ == "__main__":
 
     costs = prepare_costs(
         snakemake.input.costs,
-        snakemake.config["costs"]["USD2013_to_EUR2013"],
+        snakemake.params.USD2013_to_EUR2013,
         eval(snakemake.wildcards.discountrate),
         Nyears,
-        snakemake.config["costs"]["lifetime"],
+        snakemake.params.lifetime,
     )
 
     # get hydrogen export buses/ports

--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -205,7 +205,7 @@ if __name__ == "__main__":
 
     costs = prepare_costs(
         snakemake.input.costs,
-        snakemake.params.USD2013_to_EUR2013,
+        snakemake.params.USD_to_EUR,
         eval(snakemake.wildcards.discountrate),
         Nyears,
         snakemake.params.lifetime,


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

This PR is part of adding Params to all Rules in Snakemake under Issue #330 

The following Rules are already done including the work done in this PR:

- [x] add_export.py
build_base_energy_totals.py
build_base_industry_totals.py
build_clustered_population_layouts.py
build_cop_profiles.py
build_heat_demand.py
build_industrial_database.py
build_industrial_distribution_key.py
build_industry_demand.py
build_population_layouts.py
build_ship_profile.py
build_solar_thermal_profiles.py
build_temperature_profiles.py
copy_config.py
helpers.py
make_summary.py
override_respot.py
plot_network.py
plot_network_eur.py
plot_summary.py
prepare_airports.py
prepare_db.py
prepare_energy_totals.py
prepare_gas_network.py
prepare_heat_data.py
prepare_ports.py
prepare_sector_network.py
prepare_transport_data.py
prepare_transport_data_input.py
prepare_urban_percent.py
solve_network.py

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
