### PR TITLE
Add Params to Rule build_base_energy_totals

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -318,10 +318,10 @@ rule prepare_heat_data:
 
 rule build_base_energy_totals:
     params:
-        space_heat_share= config["sector"]["space_heat_share"],
-        update_data= config["demand_data"]["update_data"],
-        base_year= config["demand_data"]["base_year"],
-        countries= config["countries"],
+        space_heat_share=config["sector"]["space_heat_share"],
+        update_data=config["demand_data"]["update_data"],
+        base_year=config["demand_data"]["base_year"],
+        countries=config["countries"],
     input:
         unsd_paths="data/demand/unsd/paths/Energy_Statistics_Database.xlsx",
     output:

--- a/Snakefile
+++ b/Snakefile
@@ -317,6 +317,11 @@ rule prepare_heat_data:
 
 
 rule build_base_energy_totals:
+    params:
+        space_heat_share= config["sector"]["space_heat_share"],
+        update_data= config["demand_data"]["update_data"],
+        base_year= config["demand_data"]["base_year"],
+        countries= config["countries"],
     input:
         unsd_paths="data/demand/unsd/paths/Energy_Statistics_Database.xlsx",
     output:

--- a/scripts/build_base_energy_totals.py
+++ b/scripts/build_base_energy_totals.py
@@ -136,11 +136,11 @@ def calc_sector(sector):
                     round(
                         df_sector[df_sector.Commodity.isin(heat)].Quantity_TWh.sum(), 4
                     )
-                    * snakemake.config["sector"]["space_heat_share"]
+                    * snakemake.params.space_heat_share
                 )
                 energy_totals_base.at[country, "total residential water"] = round(
                     df_sector[df_sector.Commodity.isin(heat)].Quantity_TWh.sum(), 4
-                ) * (1 - snakemake.config["sector"]["space_heat_share"])
+                ) * (1 - snakemake.params.space_heat_share)
 
             elif sector == "services":
                 energy_totals_base.at[country, "services electricity"] = round(
@@ -166,11 +166,11 @@ def calc_sector(sector):
                     round(
                         df_sector[df_sector.Commodity.isin(heat)].Quantity_TWh.sum(), 4
                     )
-                    * snakemake.config["sector"]["space_heat_share"]
+                    * snakemake.params.space_heat_share
                 )
                 energy_totals_base.at[country, "total services water"] = round(
                     df_sector[df_sector.Commodity.isin(heat)].Quantity_TWh.sum(), 4
-                ) * (1 - snakemake.config["sector"]["space_heat_share"])
+                ) * (1 - snakemake.params.space_heat_share)
 
             elif sector == "road":
                 energy_totals_base.at[country, "total road"] = round(
@@ -273,7 +273,7 @@ if __name__ == "__main__":
     df = df.to_dict("dict")
     d = df["Link"]
 
-    if snakemake.config["demand_data"]["update_data"]:
+    if snakemake.params.update_data:
         # Delete and existing files to avoid duplication and double counting
 
         files = glob.glob("data/demand/unsd/data/*.txt")
@@ -363,8 +363,8 @@ if __name__ == "__main__":
     }
 
     # Fetch country list and demand base year from the config file
-    year = snakemake.config["demand_data"]["base_year"]
-    countries = snakemake.config["countries"]
+    year = snakemake.params.base_year
+    countries = snakemake.params.countries
     # countries = ["NG", "BJ"]
 
     # Filter for the year and country


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

This PR is part of adding Params to all Rules in Snakemake under Issue https://github.com/pypsa-meets-earth/pypsa-earth-sec/issues/330

The following Rules are already done including the work done in this PR:

- [x] add_export.py
- [x] build_base_energy_totals.py
build_base_industry_totals.py
build_clustered_population_layouts.py
build_cop_profiles.py
build_heat_demand.py
build_industrial_database.py
build_industrial_distribution_key.py
build_industry_demand.py
build_population_layouts.py
build_ship_profile.py
build_solar_thermal_profiles.py
build_temperature_profiles.py
copy_config.py
helpers.py
make_summary.py
override_respot.py
plot_network.py
plot_network_eur.py
plot_summary.py
prepare_airports.py
prepare_db.py
prepare_energy_totals.py
prepare_gas_network.py
prepare_heat_data.py
prepare_ports.py
prepare_sector_network.py
prepare_transport_data.py
prepare_transport_data_input.py
prepare_urban_percent.py
solve_network.py

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
