### PR TITLE
Add Params to Rule build_base_industry_totals

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -655,6 +655,10 @@ rule build_industrial_distribution_key:  #default data
 
 
 rule build_base_industry_totals:  #default data
+    params:
+        base_year= config["demand_data"]["base_year"],
+        countries= config["countries"],
+        other_industries= config["demand_data"]["other_industries"],
     input:
         #industrial_production_per_country="data/industrial_production_per_country.csv",
         #unsd_path="data/demand/unsd/data/",

--- a/scripts/build_base_industry_totals.py
+++ b/scripts/build_base_industry_totals.py
@@ -110,17 +110,17 @@ if __name__ == "__main__":
 
     # Loading config file and wild cards
 
-    year = snakemake.config["demand_data"]["base_year"]
-    countries = snakemake.config["countries"]
+    year = snakemake.params.base_year
+    countries = snakemake.params.countries
     # countries = ["DE", "US", "EG", "MA", "UA", "UK"]
     # countries = ["EG", "BH"]
 
     investment_year = int(snakemake.wildcards.planning_horizons)
     demand_sc = snakemake.wildcards.demand
     no_years = int(snakemake.wildcards.planning_horizons) - int(
-        snakemake.config["demand_data"]["base_year"]
+        snakemake.params.base_year
     )
-    include_other = snakemake.config["demand_data"]["other_industries"]
+    include_other = snakemake.params.other_industries
 
     industry_list = [
         "iron and steel",


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

This PR is part of adding Params to all Rules in Snakemake under Issue https://github.com/pypsa-meets-earth/pypsa-earth-sec/issues/330

The following Rules are already done including the work done in this PR:

- [x] add_export.py
- [x] build_base_energy_totals.py
- [x] build_base_industry_totals.py
build_clustered_population_layouts.py
build_cop_profiles.py
build_heat_demand.py
build_industrial_database.py
build_industrial_distribution_key.py
build_industry_demand.py
build_population_layouts.py
build_ship_profile.py
build_solar_thermal_profiles.py
build_temperature_profiles.py
copy_config.py
helpers.py
make_summary.py
override_respot.py
plot_network.py
plot_network_eur.py
plot_summary.py
prepare_airports.py
prepare_db.py
prepare_energy_totals.py
prepare_gas_network.py
prepare_heat_data.py
prepare_ports.py
prepare_sector_network.py
prepare_transport_data.py
prepare_transport_data_input.py
prepare_urban_percent.py
solve_network.py

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
