### PR TITLE
Add Params to Rule build_cop_profiles

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -272,6 +272,8 @@ rule prepare_transport_data:
 
 
 rule build_cop_profiles:
+    params:
+        heat_pump_sink_T= config["sector"]["heat_pump_sink_T"],
     input:
         temp_soil_total="resources/temperatures/temp_soil_total_elec_s{simpl}_{clusters}.nc",
         temp_soil_rural="resources/temperatures/temp_soil_rural_elec_s{simpl}_{clusters}.nc",

--- a/Snakefile
+++ b/Snakefile
@@ -273,7 +273,7 @@ rule prepare_transport_data:
 
 rule build_cop_profiles:
     params:
-        heat_pump_sink_T= config["sector"]["heat_pump_sink_T"],
+        heat_pump_sink_T=config["sector"]["heat_pump_sink_T"],
     input:
         temp_soil_total="resources/temperatures/temp_soil_total_elec_s{simpl}_{clusters}.nc",
         temp_soil_rural="resources/temperatures/temp_soil_rural_elec_s{simpl}_{clusters}.nc",

--- a/scripts/build_cop_profiles.py
+++ b/scripts/build_cop_profiles.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
         for source in ["air", "soil"]:
             source_T = xr.open_dataarray(snakemake.input[f"temp_{source}_{area}"])
 
-            delta_T = snakemake.config["sector"]["heat_pump_sink_T"] - source_T
+            delta_T = snakemake.params.heat_pump_sink_T - source_T
 
             cop = coefficient_of_performance(delta_T, source)
 


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

This PR is part of adding Params to all Rules in Snakemake under Issue https://github.com/pypsa-meets-earth/pypsa-earth-sec/issues/330

The following Rules are already done including the work done in this PR:

- [x] add_export.py
- [x] build_base_energy_totals.py
- [x] build_base_industry_totals.py
- [x] build_clustered_population_layouts.py   ->  _(Had no changes to be done)_
- [x] build_cop_profiles.py
build_heat_demand.py
build_industrial_database.py
build_industrial_distribution_key.py
build_industry_demand.py
build_population_layouts.py
build_ship_profile.py
build_solar_thermal_profiles.py
build_temperature_profiles.py
copy_config.py
helpers.py
make_summary.py
override_respot.py
plot_network.py
plot_network_eur.py
plot_summary.py
prepare_airports.py
prepare_db.py
prepare_energy_totals.py
prepare_gas_network.py
prepare_heat_data.py
prepare_ports.py
prepare_sector_network.py
prepare_transport_data.py
prepare_transport_data_input.py
prepare_urban_percent.py
solve_network.py

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
