### PR TITLE
Add Params to build_industrial_distribution_key

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -633,6 +633,11 @@ rule clean:
 
 
 rule build_industrial_distribution_key:  #default data
+    params:
+        countries= config["countries"],
+        gadm_level= config["sector"]["gadm_level"],
+        alternative_clustering= config["clustering_options"]["alternative_clustering"],
+        industry_database= config["custom_data"]["industry_database"],
     input:
         regions_onshore=pypsaearth(
             "resources/bus_regions/regions_onshore_elec_s{simpl}_{clusters}.geojson"

--- a/Snakefile
+++ b/Snakefile
@@ -634,10 +634,10 @@ rule clean:
 
 rule build_industrial_distribution_key:  #default data
     params:
-        countries= config["countries"],
-        gadm_level= config["sector"]["gadm_level"],
-        alternative_clustering= config["clustering_options"]["alternative_clustering"],
-        industry_database= config["custom_data"]["industry_database"],
+        countries=config["countries"],
+        gadm_level=config["sector"]["gadm_level"],
+        alternative_clustering=config["clustering_options"]["alternative_clustering"],
+        industry_database=config["custom_data"]["industry_database"],
     input:
         regions_onshore=pypsaearth(
             "resources/bus_regions/regions_onshore_elec_s{simpl}_{clusters}.geojson"

--- a/scripts/build_industrial_distribution_key.py
+++ b/scripts/build_industrial_distribution_key.py
@@ -123,7 +123,6 @@ if __name__ == "__main__":
         )
         sets_path_to_root("pypsa-earth-sec")
 
-
     regions = gpd.read_file(snakemake.input.regions_onshore)
     shapes_path = snakemake.input.shapes_path
 
@@ -172,10 +171,15 @@ if __name__ == "__main__":
     industry = geo_locs.industry.unique()
 
     industrial_database = map_industry_to_buses(
-        geo_locs[geo_locs.quality != "unavailable"], 
-        countries, gadm_level, shapes_path, gadm_clustering
+        geo_locs[geo_locs.quality != "unavailable"],
+        countries,
+        gadm_level,
+        shapes_path,
+        gadm_clustering,
     )
 
-    keys = build_nodal_distribution_key(industrial_database, regions, industry, countries)
+    keys = build_nodal_distribution_key(
+        industrial_database, regions, industry, countries
+    )
 
     keys.to_csv(snakemake.output.industrial_distribution_key)


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

This PR is part of adding Params to all Rules in Snakemake under Issue https://github.com/pypsa-meets-earth/pypsa-earth-sec/issues/330

The following Rules are already done including the work done in this PR:

- [x] add_export.py
- [x] build_base_energy_totals.py
- [x] build_base_industry_totals.py
- [x] build_clustered_population_layouts.py -> _(Had no changes to be done)_
- [x] build_cop_profiles.py
- [x] build_heat_demand.py
- [x] build_industrial_database.py -> _(Had no changes to be done)_
- [x] build_industrial_distribution_key.py
build_industry_demand.py
build_population_layouts.py
build_ship_profile.py
build_solar_thermal_profiles.py
build_temperature_profiles.py
copy_config.py
helpers.py
make_summary.py
override_respot.py
plot_network.py
plot_network_eur.py
plot_summary.py
prepare_airports.py
prepare_db.py
prepare_energy_totals.py
prepare_gas_network.py
prepare_heat_data.py
prepare_ports.py
prepare_sector_network.py
prepare_transport_data.py
prepare_transport_data_input.py
prepare_urban_percent.py
solve_network.py

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.


