### PR TITLE
Add Params to build_industry_demand

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -671,6 +671,12 @@ rule build_base_industry_totals:  #default data
 
 
 rule build_industry_demand:  #default data
+    params:
+        countries= config["countries"],
+        industry_demand= config["custom_data"]["industry_demand"],
+        base_year= config["demand_data"]["base_year"],
+        industry_util_factor= config["sector"]["industry_util_factor"],
+        aluminium_year= config["demand_data"]["aluminium_year"],
     input:
         industrial_distribution_key="resources/demand/industrial_distribution_key_elec_s{simpl}_{clusters}.csv",
         #industrial_production_per_country_tomorrow="resources/demand/industrial_production_per_country_tomorrow_{planning_horizons}_{demand}.csv",

--- a/scripts/build_industry_demand.py
+++ b/scripts/build_industry_demand.py
@@ -64,9 +64,9 @@ if __name__ == "__main__":
 
         sets_path_to_root("pypsa-earth-sec")
 
-    countries = snakemake.config["countries"]
+    countries = snakemake.params.countries
 
-    if snakemake.config["custom_data"]["industry_demand"]:
+    if snakemake.params.industry_demand:
         _logger.info(
             "Fetching custom industry demand data.. expecting file at 'data_custom/industry_demand_{0}_{1}.csv'".format(
                 snakemake.wildcards["demand"], snakemake.wildcards["planning_horizons"]
@@ -102,7 +102,7 @@ if __name__ == "__main__":
 
     else:
         no_years = int(snakemake.wildcards.planning_horizons) - int(
-            snakemake.config["demand_data"]["base_year"]
+            snakemake.params.base_year
         )
 
         cagr = read_csv_nafix(snakemake.input.industry_growth_cagr, index_col=0)
@@ -131,7 +131,7 @@ if __name__ == "__main__":
         # non-used line; commented out
         # industry_totals = (production_tom * industry_base_totals).fillna(0)
 
-        industry_util_factor = snakemake.config["sector"]["industry_util_factor"]
+        industry_util_factor = snakemake.params.industry_util_factor
 
         # Load distribution keys
         keys_path = snakemake.input.industrial_distribution_key
@@ -208,7 +208,7 @@ if __name__ == "__main__":
         countries_geo = geo_locs.index.unique().intersection(countries)
         geo_locs = match_technology(geo_locs).loc[countries_geo]
 
-        aluminium_year = snakemake.config["demand_data"]["aluminium_year"]
+        aluminium_year = snakemake.params.aluminium_year
         AL = read_csv_nafix("data/AL_production.csv", index_col=0)
         AL_prod_tom = AL.query("Year == @aluminium_year and index in @countries_geo")[
             "production[ktons/a]"


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

This PR is part of adding Params to all Rules in Snakemake under Issue https://github.com/pypsa-meets-earth/pypsa-earth-sec/issues/330

The following Rules are already done including the work done in this PR:

- [x] add_export.py
- [x] build_base_energy_totals.py
- [x] build_base_industry_totals.py
- [x] build_clustered_population_layouts.py -> _(Had no changes to be done)_
- [x] build_cop_profiles.py
- [x] build_heat_demand.py
- [x] build_industrial_database.py -> _(Had no changes to be done)_
- [x] build_industrial_distribution_key.py
- [x] build_industry_demand.py
build_population_layouts.py
build_ship_profile.py
build_solar_thermal_profiles.py
build_temperature_profiles.py
copy_config.py
helpers.py
make_summary.py
override_respot.py
plot_network.py
plot_network_eur.py
plot_summary.py
prepare_airports.py
prepare_db.py
prepare_energy_totals.py
prepare_gas_network.py
prepare_heat_data.py
prepare_ports.py
prepare_sector_network.py
prepare_transport_data.py
prepare_transport_data_input.py
prepare_urban_percent.py
solve_network.py

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.


