### PR TITLE
Add Params to build_ship_profile

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -204,6 +204,9 @@ rule prepare_sector_network:
 
 
 rule build_ship_profile:
+    params:
+        snapshots= config["snapshots"],
+        ship_opts= config["export"]["ship"],
     output:
         ship_profile="resources/ship_profile_{h2export}TWh.csv",
     script:

--- a/Snakefile
+++ b/Snakefile
@@ -205,8 +205,8 @@ rule prepare_sector_network:
 
 rule build_ship_profile:
     params:
-        snapshots= config["snapshots"],
-        ship_opts= config["export"]["ship"],
+        snapshots=config["snapshots"],
+        ship_opts=config["export"]["ship"],
     output:
         ship_profile="resources/ship_profile_{h2export}TWh.csv",
     script:

--- a/scripts/build_ship_profile.py
+++ b/scripts/build_ship_profile.py
@@ -44,7 +44,7 @@ def build_ship_profile(export_volume, ship_opts):
     )  # extend ship series to above 8760 hours
 
     # Add index, cut profile after length of snapshots
-    snapshots = pd.date_range(freq="h", **snakemake.config["snapshots"])
+    snapshots = pd.date_range(freq="h", **snakemake.params.snapshots)
     ship = ship[: len(snapshots)]
     ship.index = snapshots
 
@@ -72,7 +72,7 @@ if __name__ == "__main__":
         sets_path_to_root("pypsa-earth-sec")
 
     # Get parameters from config and wildcard
-    ship_opts = snakemake.config["export"]["ship"]
+    ship_opts = snakemake.params.ship_opts
     export_volume = eval(snakemake.wildcards.h2export)
 
     # Create export profile
@@ -81,7 +81,7 @@ if __name__ == "__main__":
     else:
         export_profile = pd.Series(
             0,
-            index=pd.date_range(freq="h", **snakemake.config["snapshots"]),
+            index=pd.date_range(freq="h", **snakemake.params.snapshots),
             name="profile",
         )
 


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

This PR is part of adding Params to all Rules in Snakemake under Issue https://github.com/pypsa-meets-earth/pypsa-earth-sec/issues/330

The following Rules are already done including the work done in this PR:

- [x] add_export.py
- [x] build_base_energy_totals.py
- [x] build_base_industry_totals.py
- [x] build_clustered_population_layouts.py -> _(Had no changes to be done)_
- [x] build_cop_profiles.py
- [x] build_heat_demand.py
- [x] build_industrial_database.py -> _(Had no changes to be done)_
- [x] build_industrial_distribution_key.py
- [x] build_industry_demand.py
- [x] build_population_layouts.py
- [x] build_ship_profile.py
build_solar_thermal_profiles.py
build_temperature_profiles.py
copy_config.py
helpers.py
make_summary.py
override_respot.py
plot_network.py
plot_network_eur.py
plot_summary.py
prepare_airports.py
prepare_db.py
prepare_energy_totals.py
prepare_gas_network.py
prepare_heat_data.py
prepare_ports.py
prepare_sector_network.py
prepare_transport_data.py
prepare_transport_data_input.py
prepare_urban_percent.py
solve_network.py

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
