### PR TITLE
Add Params to build_temperature_profiles

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -431,7 +431,7 @@ rule build_heat_demand:
 
 rule build_temperature_profiles:
     params:
-        snapshots= config["snapshots"],
+        snapshots=config["snapshots"],
     input:
         pop_layout_total="resources/population_shares/pop_layout_total.nc",
         pop_layout_urban="resources/population_shares/pop_layout_urban.nc",

--- a/Snakefile
+++ b/Snakefile
@@ -430,6 +430,8 @@ rule build_heat_demand:
 
 
 rule build_temperature_profiles:
+    params:
+        snapshots= config["snapshots"],
     input:
         pop_layout_total="resources/population_shares/pop_layout_total.nc",
         pop_layout_urban="resources/population_shares/pop_layout_urban.nc",

--- a/scripts/build_temperature_profiles.py
+++ b/scripts/build_temperature_profiles.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
         )
         sets_path_to_root("pypsa-earth-sec")
 
-    time = pd.date_range(freq="h", **snakemake.config["snapshots"])
+    time = pd.date_range(freq="h", **snakemake.params.snapshots)
     cutout_path = (
         snakemake.input.cutout
     )  # os.path.abspath(snakemake.config["atlite"]["cutout"])


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

This PR is part of adding Params to all Rules in Snakemake under Issue https://github.com/pypsa-meets-earth/pypsa-earth-sec/issues/330

The following Rules are already done including the work done in this PR:

- [x] add_export.py
- [x] build_base_energy_totals.py
- [x] build_base_industry_totals.py
- [x] build_clustered_population_layouts.py -> _(Had no changes to be done)_
- [x] build_cop_profiles.py
- [x] build_heat_demand.py
- [x] build_industrial_database.py -> _(Had no changes to be done)_
- [x] build_industrial_distribution_key.py
- [x] build_industry_demand.py
- [x] build_population_layouts.py
- [x] build_ship_profile.py
- [x] build_solar_thermal_profiles.py
- [x] build_temperature_profiles.py
copy_config.py
helpers.py
make_summary.py
override_respot.py
plot_network.py
plot_network_eur.py
plot_summary.py
prepare_airports.py
prepare_db.py
prepare_energy_totals.py
prepare_gas_network.py
prepare_heat_data.py
prepare_ports.py
prepare_sector_network.py
prepare_transport_data.py
prepare_transport_data_input.py
prepare_urban_percent.py
solve_network.py

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.

