### PR TITLE
Add Params make_summary

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -499,6 +499,15 @@ rule solve_network:
 
 
 rule make_summary:
+    params:
+        planning_horizons= config["scenario"]["planning_horizons"],
+        results_dir= config["results_dir"],
+        summary_dir= config["summary_dir"],
+        run= config["run"],
+        scenario_config= config["scenario"],
+        costs_config= config["costs"],
+        h2export_qty= config["export"]["h2export"],
+        foresight= snakemake.config["foresight"],
     input:
         overrides="data/override_component_attrs",
         networks=expand(

--- a/Snakefile
+++ b/Snakefile
@@ -507,7 +507,7 @@ rule make_summary:
         scenario_config=config["scenario"],
         costs_config=config["costs"],
         h2export_qty=config["export"]["h2export"],
-        foresight=snakemake.config["foresight"],
+        foresight=config["foresight"],
     input:
         overrides="data/override_component_attrs",
         networks=expand(

--- a/Snakefile
+++ b/Snakefile
@@ -500,14 +500,14 @@ rule solve_network:
 
 rule make_summary:
     params:
-        planning_horizons= config["scenario"]["planning_horizons"],
-        results_dir= config["results_dir"],
-        summary_dir= config["summary_dir"],
-        run= config["run"],
-        scenario_config= config["scenario"],
-        costs_config= config["costs"],
-        h2export_qty= config["export"]["h2export"],
-        foresight= snakemake.config["foresight"],
+        planning_horizons=config["scenario"]["planning_horizons"],
+        results_dir=config["results_dir"],
+        summary_dir=config["summary_dir"],
+        run=config["run"],
+        scenario_config=config["scenario"],
+        costs_config=config["costs"],
+        h2export_qty=config["export"]["h2export"],
+        foresight=snakemake.config["foresight"],
     input:
         overrides="data/override_component_attrs",
         networks=expand(

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -188,7 +188,7 @@ def calculate_costs(n, label, costs):
 
 
 def calculate_cumulative_cost():
-    planning_horizons = snakemake.config["scenario"]["planning_horizons"]
+    planning_horizons = snakemake.params.planning_horizons
 
     cumulative_cost = pd.DataFrame(
         index=df["costs"].sum().index,
@@ -694,18 +694,18 @@ if __name__ == "__main__":
             discountrate,
             demand,
             export,
-        ): snakemake.config["results_dir"]
-        + snakemake.config["run"]
+        ): snakemake.params.results_dir
+        + snakemake.params.run
         + f"/postnetworks/elec_s{simpl}_{cluster}_ec_l{ll}_{opt}_{sopt}_{planning_horizon}_{discountrate}_{demand}_{export}export.nc"  # snakemake.config['results_dir'] + snakemake.config['run'] + f'/postnetworks/elec_s{simpl}_{cluster}_lv{lv}_{opt}_{sector_opt}_{planning_horizon}.nc' \
-        for simpl in snakemake.config["scenario"]["simpl"]
-        for cluster in snakemake.config["scenario"]["clusters"]
-        for ll in snakemake.config["scenario"]["ll"]
-        for opt in snakemake.config["scenario"]["opts"]
-        for sopt in snakemake.config["scenario"]["sopts"]
-        for planning_horizon in snakemake.config["scenario"]["planning_horizons"]
-        for discountrate in snakemake.config["costs"]["discountrate"]
-        for demand in snakemake.config["scenario"]["demand"]
-        for export in snakemake.config["export"]["h2export"]
+        for simpl in snakemake.params.scenario_config["simpl"]
+        for cluster in snakemake.params.scenario_config["clusters"]
+        for ll in snakemake.params.scenario_config["ll"]
+        for opt in snakemake.params.scenario_config["opts"]
+        for sopt in snakemake.params.scenario_config["sopts"]
+        for planning_horizon in snakemake.params.scenario_config["planning_horizons"]
+        for discountrate in snakemake.params.costs_config["discountrate"]
+        for demand in snakemake.params.scenario_config["demand"]
+        for export in snakemake.params.h2export_qty
     }
 
     print(networks_dict)
@@ -714,10 +714,10 @@ if __name__ == "__main__":
 
     costs_db = prepare_costs(
         snakemake.input.costs,
-        snakemake.config["costs"]["USD2013_to_EUR2013"],
-        snakemake.config["costs"]["discountrate"][0],
+        snakemake.params.costs_config["USD2013_to_EUR2013"],
+        snakemake.params.costs_config["discountrate"][0],
         Nyears,
-        snakemake.config["costs"]["lifetime"],
+        snakemake.params.costs_config["lifetime"],
     )
 
     df = make_summaries(networks_dict)
@@ -726,11 +726,11 @@ if __name__ == "__main__":
 
     to_csv(df)
 
-    if snakemake.config["foresight"] == "myopic":
+    if snakemake.params.foresight == "myopic":
         cumulative_cost = calculate_cumulative_cost().round(3)
         cumulative_cost.to_csv(
-            snakemake.config["summary_dir"]
+            snakemake.params.summary_dir
             + "/"
-            + snakemake.config["run"]
+            + snakemake.params.run
             + "/csvs/cumulative_cost.csv"
         )


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

This PR is part of adding Params to all Rules in Snakemake under Issue https://github.com/pypsa-meets-earth/pypsa-earth-sec/issues/330

The following Rules are already done including the work done in this PR:

- [x] add_export.py
- [x] build_base_energy_totals.py
- [x] build_base_industry_totals.py
- [x] build_clustered_population_layouts.py -> _(Had no changes to be done)_
- [x] build_cop_profiles.py
- [x] build_heat_demand.py
- [x] build_industrial_database.py -> _(Had no changes to be done)_
- [x] build_industrial_distribution_key.py
- [x] build_industry_demand.py
- [x] build_population_layouts.py
- [x] build_ship_profile.py
- [x] build_solar_thermal_profiles.py
- [x] build_temperature_profiles.py
- [x] copy_config.py
- [x] helpers.py -> _(Had no changes to be done)_
- [x] make_summary.py
override_respot.py
plot_network.py
plot_network_eur.py
plot_summary.py
prepare_airports.py
prepare_db.py
prepare_energy_totals.py
prepare_gas_network.py
prepare_heat_data.py
prepare_ports.py
prepare_sector_network.py
prepare_transport_data.py
prepare_transport_data_input.py
prepare_urban_percent.py
solve_network.py

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.



