### PR TITLE
Add to override_respot + panning_horizons wildcard

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -48,6 +48,7 @@ wildcard_constraints:
     discountrate="[-+a-zA-Z0-9\.\s]*",
     demand="[-+a-zA-Z0-9\.\s]*",
     h2export="[0-9]+m?|all",
+    planning_horizons="20[2-9][0-9]|2100",
 
 
 if not config.get("disable_subworkflow", False):
@@ -229,6 +230,10 @@ rule add_export:
 
 
 rule override_respot:
+    params:
+        run= config.run,
+        custom_data= config["custom_data"],
+        countries= config["countries"],
     input:
         **{
             f"custom_res_pot_{tech}_{planning_horizons}_{discountrate}": f"resources/custom_renewables/{tech}_{planning_horizons}_{discountrate}_potential.csv"

--- a/Snakefile
+++ b/Snakefile
@@ -231,7 +231,7 @@ rule add_export:
 
 rule override_respot:
     params:
-        run=config.run,
+        run=config["run"],
         custom_data=config["custom_data"],
         countries=config["countries"],
     input:

--- a/Snakefile
+++ b/Snakefile
@@ -231,9 +231,9 @@ rule add_export:
 
 rule override_respot:
     params:
-        run= config.run,
-        custom_data= config["custom_data"],
-        countries= config["countries"],
+        run=config.run,
+        custom_data=config["custom_data"],
+        countries=config["countries"],
     input:
         **{
             f"custom_res_pot_{tech}_{planning_horizons}_{discountrate}": f"resources/custom_renewables/{tech}_{planning_horizons}_{discountrate}_potential.csv"

--- a/scripts/override_respot.py
+++ b/scripts/override_respot.py
@@ -102,7 +102,6 @@ if __name__ == "__main__":
         else:
             print("No RES potential techs to override...")
 
-
         if snakemake.params.custom_data["elec_demand"]:
             for country in countries:
                 n.loads_t.p_set.filter(like=country)[buses] = (

--- a/scripts/override_respot.py
+++ b/scripts/override_respot.py
@@ -36,7 +36,7 @@ def override_values(tech, year, dr):
         n.mremove("Generator", to_drop)
 
     if snakemake.wildcards["planning_horizons"] == 2050:
-        directory = "results/" + snakemake.config.run.replace("2050", "2030")
+        directory = "results/" + snakemake.params.run.replace("2050", "2030")
         n_name = snakemake.input.network.split("/")[-1].replace(
             n.config["scenario"]["clusters"], ""
         )
@@ -85,12 +85,12 @@ if __name__ == "__main__":
     overrides = override_component_attrs(snakemake.input.overrides)
     n = pypsa.Network(snakemake.input.network, override_component_attrs=overrides)
     m = n.copy()
-    if snakemake.config["custom_data"]["renewables"]:
+    if snakemake.params.custom_data["renewables"]:
         buses = list(n.buses[n.buses.carrier == "AC"].index)
         energy_totals = pd.read_csv(snakemake.input.energy_totals, index_col=0)
-        countries = snakemake.config["countries"]
-        if snakemake.config["custom_data"]["renewables"]:
-            techs = snakemake.config["custom_data"]["renewables"]
+        countries = snakemake.params.countries
+        if snakemake.params.custom_data["renewables"]:
+            techs = snakemake.params.custom_data["renewables"]
             year = snakemake.wildcards["planning_horizons"]
             dr = snakemake.wildcards["discountrate"]
 
@@ -102,24 +102,8 @@ if __name__ == "__main__":
         else:
             print("No RES potential techs to override...")
 
-        if (
-            snakemake.config["custom_data"]["add_existing"]
-            and snakemake.wildcards["planning_horizons"] == "2030"
-        ):
-            n.generators.loc["MAR010003 onwind", "p_nom_min"] = 50
-            n.generators.loc["MAR010005 offwind", "p_nom_min"] = 120
-            n.generators.loc["MAR010005 offwind", "p_nom_max"] = 120
-            n.generators.loc["MAR010001 onwind", "p_nom_min"] = 154
-            n.generators.loc["MAR004005 onwind", "p_nom_min"] = 150
-            n.generators.loc["MAR003003 onwind", "p_nom_min"] = 180
-            n.generators.loc["MAR006003 onwind", "p_nom_min"] = 60
-            n.generators.loc["MAR011001 onwind", "p_nom_min"] = 208
 
-            n.generators.loc["MAR003001 csp", "p_nom_min"] = 500
-
-            n.generators.loc["MAR003001 solar", "p_nom_min"] = 72
-
-        if snakemake.config["custom_data"]["elec_demand"]:
+        if snakemake.params.custom_data["elec_demand"]:
             for country in countries:
                 n.loads_t.p_set.filter(like=country)[buses] = (
                     (


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

This PR is part of adding Params to all Rules in Snakemake under Issue https://github.com/pypsa-meets-earth/pypsa-earth-sec/issues/330

The following Rules are already done including the work done in this PR:

- [x] add_export.py
- [x] build_base_energy_totals.py
- [x] build_base_industry_totals.py
- [x] build_clustered_population_layouts.py -> _(Had no changes to be done)_
- [x] build_cop_profiles.py
- [x] build_heat_demand.py
- [x] build_industrial_database.py -> _(Had no changes to be done)_
- [x] build_industrial_distribution_key.py
- [x] build_industry_demand.py
- [x] build_population_layouts.py
- [x] build_ship_profile.py
- [x] build_solar_thermal_profiles.py
- [x] build_temperature_profiles.py
- [x] copy_config.py
- [x] helpers.py -> _(Had no changes to be done)_
- [x] make_summary.py
- [x] override_respot.py
plot_network.py
plot_network_eur.py
plot_summary.py
prepare_airports.py
prepare_db.py
prepare_energy_totals.py
prepare_gas_network.py
prepare_heat_data.py
prepare_ports.py
prepare_sector_network.py
prepare_transport_data.py
prepare_transport_data_input.py
prepare_urban_percent.py
solve_network.py

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.




