### PR TITLE
Add Params to prepare_airports

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -124,6 +124,8 @@ rule prepare_ports:
 
 
 rule prepare_airports:
+    params:
+        airport_sizing_factor= config["sector"]["airport_sizing_factor"],
     output:
         ports="data/airports.csv",  # TODO move from data to resources
     script:

--- a/Snakefile
+++ b/Snakefile
@@ -125,7 +125,7 @@ rule prepare_ports:
 
 rule prepare_airports:
     params:
-        airport_sizing_factor= config["sector"]["airport_sizing_factor"],
+        airport_sizing_factor=config["sector"]["airport_sizing_factor"],
     output:
         ports="data/airports.csv",  # TODO move from data to resources
     script:

--- a/scripts/prepare_airports.py
+++ b/scripts/prepare_airports.py
@@ -94,9 +94,7 @@ if __name__ == "__main__":
 
     df.insert(2, "airport_size_nr", 1)
     df.loc[df["type"].isin(["medium_airport"]), "airport_size_nr"] = 1
-    df.loc[df["type"].isin(["large_airport"]), "airport_size_nr"] = snakemake.config[
-        "sector"
-    ]["airport_sizing_factor"]
+    df.loc[df["type"].isin(["large_airport"]), "airport_size_nr"] = snakemake.params.airport_sizing_factor
 
     # Calculate the number of total airports size
     df1 = df.copy()

--- a/scripts/prepare_airports.py
+++ b/scripts/prepare_airports.py
@@ -94,7 +94,9 @@ if __name__ == "__main__":
 
     df.insert(2, "airport_size_nr", 1)
     df.loc[df["type"].isin(["medium_airport"]), "airport_size_nr"] = 1
-    df.loc[df["type"].isin(["large_airport"]), "airport_size_nr"] = snakemake.params.airport_sizing_factor
+    df.loc[
+        df["type"].isin(["large_airport"]), "airport_size_nr"
+    ] = snakemake.params.airport_sizing_factor
 
     # Calculate the number of total airports size
     df1 = df.copy()


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

This PR is part of adding Params to all Rules in Snakemake under Issue https://github.com/pypsa-meets-earth/pypsa-earth-sec/issues/330

The following Rules are already done including the work done in this PR:

- [x] add_export.py
- [x] build_base_energy_totals.py
- [x] build_base_industry_totals.py
- [x] build_clustered_population_layouts.py -> _(Had no changes to be done)_
- [x] build_cop_profiles.py
- [x] build_heat_demand.py
- [x] build_industrial_database.py -> _(Had no changes to be done)_
- [x] build_industrial_distribution_key.py
- [x] build_industry_demand.py
- [x] build_population_layouts.py
- [x] build_ship_profile.py
- [x] build_solar_thermal_profiles.py
- [x] build_temperature_profiles.py
- [x] copy_config.py
- [x] helpers.py -> _(Had no changes to be done)_
- [x] make_summary.py
- [x] override_respot.py
plot_network.py
plot_network_eur.py
plot_summary.py
- [x] prepare_airports.py
prepare_db.py
prepare_energy_totals.py
prepare_gas_network.py
prepare_heat_data.py
prepare_ports.py
prepare_sector_network.py
prepare_transport_data.py
prepare_transport_data_input.py
prepare_urban_percent.py
solve_network.py

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.





