### PR TITLE
Add Params to prepare_db and energy_totals

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -326,6 +326,10 @@ rule build_base_energy_totals:
 
 
 rule prepare_energy_totals:
+    params:
+        countries= config["countries"],
+        base_year= config["demand_data"]["base_year"],
+        sector_options= config["sector"],
     input:
         unsd_paths="data/energy_totals_base.csv",
         efficiency_gains_cagr="data/demand/efficiency_gains_cagr.csv",
@@ -587,6 +591,8 @@ rule build_industrial_database:
 
 
 rule prepare_db:
+    params:
+        tech_colors= config["plotting"]["tech_colors"],
     input:
         network=RDIR
         + "/postnetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export.nc",

--- a/Snakefile
+++ b/Snakefile
@@ -327,9 +327,9 @@ rule build_base_energy_totals:
 
 rule prepare_energy_totals:
     params:
-        countries= config["countries"],
-        base_year= config["demand_data"]["base_year"],
-        sector_options= config["sector"],
+        countries=config["countries"],
+        base_year=config["demand_data"]["base_year"],
+        sector_options=config["sector"],
     input:
         unsd_paths="data/energy_totals_base.csv",
         efficiency_gains_cagr="data/demand/efficiency_gains_cagr.csv",
@@ -592,7 +592,7 @@ rule build_industrial_database:
 
 rule prepare_db:
     params:
-        tech_colors= config["plotting"]["tech_colors"],
+        tech_colors=config["plotting"]["tech_colors"],
     input:
         network=RDIR
         + "/postnetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export.nc",

--- a/scripts/prepare_db.py
+++ b/scripts/prepare_db.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
 
     n0 = pypsa.Network(snakemake.input.network)
 
-    tech_colors = snakemake.config["plotting"]["tech_colors"]
+    tech_colors = snakemake.params.tech_colors
 
 
 # %%

--- a/scripts/prepare_energy_totals.py
+++ b/scripts/prepare_energy_totals.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
         )
         sets_path_to_root("pypsa-earth-sec")
 
-    countries = snakemake.config["countries"]
+    countries = snakemake.params.countries
     # countries = ["NG", "BJ"]
     investment_year = int(snakemake.wildcards.planning_horizons)
     demand_sc = snakemake.wildcards.demand  # loading the demand scenrario wildcard
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     district_heating = read_csv_nafix(snakemake.input.district_heating, index_col=0)
 
     no_years = int(snakemake.wildcards.planning_horizons) - int(
-        snakemake.config["demand_data"]["base_year"]
+        snakemake.params.base_year
     )
     growth_factors = calculate_end_values(growth_factors_cagr)
     efficiency_gains = calculate_end_values(efficiency_gains_cagr)
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     district_heating = district_heating[district_heating.index.isin(countries)]
     growth_factors = growth_factors[growth_factors.index.isin(countries)]
 
-    options = snakemake.config["sector"]
+    options = snakemake.params.sector_options
 
     fuel_cell_share = get(
         options["land_transport_fuel_cell_share"],
@@ -119,13 +119,13 @@ if __name__ == "__main__":
     )
 
     # Residential
-    efficiency_heat_oil_to_elec = snakemake.config["sector"][
+    efficiency_heat_oil_to_elec = snakemake.params.sector_options[
         "efficiency_heat_oil_to_elec"
     ]
-    efficiency_heat_biomass_to_elec = snakemake.config["sector"][
+    efficiency_heat_biomass_to_elec = snakemake.params.sector_options[
         "efficiency_heat_biomass_to_elec"
     ]
-    efficiency_heat_gas_to_elec = snakemake.config["sector"][
+    efficiency_heat_gas_to_elec = snakemake.params.sector_options[
         "efficiency_heat_gas_to_elec"
     ]
 


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

This PR is part of adding Params to all Rules in Snakemake under Issue https://github.com/pypsa-meets-earth/pypsa-earth-sec/issues/330

The following Rules are already done including the work done in this PR:

- [x] add_export.py
- [x] build_base_energy_totals.py
- [x] build_base_industry_totals.py
- [x] build_clustered_population_layouts.py -> _(Had no changes to be done)_
- [x] build_cop_profiles.py
- [x] build_heat_demand.py
- [x] build_industrial_database.py -> _(Had no changes to be done)_
- [x] build_industrial_distribution_key.py
- [x] build_industry_demand.py
- [x] build_population_layouts.py
- [x] build_ship_profile.py
- [x] build_solar_thermal_profiles.py
- [x] build_temperature_profiles.py
- [x] copy_config.py
- [x] helpers.py -> _(Had no changes to be done)_
- [x] make_summary.py
- [x] override_respot.py
plot_network.py
plot_network_eur.py
plot_summary.py
- [x] prepare_airports.py
- [x] prepare_db.py
- [x] prepare_energy_totals.py
- [x] prepare_gas_network.py
prepare_heat_data.py
- [x] prepare_ports.py -> _(Had no changes to be done)_
prepare_sector_network.py
prepare_transport_data.py
- [x] prepare_transport_data_input.py -> _(Had no changes to be done)_
- [x] prepare_urban_percent.py -> _(Had no changes to be done)_
solve_network.py

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.






