### PR TITLE
Add Params to build_population_layout

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -360,6 +360,8 @@ rule build_solar_thermal_profiles:
 
 
 rule build_population_layouts:
+    params:
+        planning_horizons= config["scenario"]["planning_horizons"][0],
     input:
         nuts3_shapes=pypsaearth("resources/shapes/gadm_shapes.geojson"),
         urban_percent="data/urban_percent.csv",

--- a/Snakefile
+++ b/Snakefile
@@ -361,7 +361,7 @@ rule build_solar_thermal_profiles:
 
 rule build_population_layouts:
     params:
-        planning_horizons= config["scenario"]["planning_horizons"][0],
+        planning_horizons=config["scenario"]["planning_horizons"][0],
     input:
         nuts3_shapes=pypsaearth("resources/shapes/gadm_shapes.geojson"),
         urban_percent="data/urban_percent.csv",

--- a/scripts/build_population_layouts.py
+++ b/scripts/build_population_layouts.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     urban_percent_df = urban_percent_df.loc[
         (
             urban_percent_df["Year"]
-            == snakemake.config["scenario"]["planning_horizons"][0]
+            == snakemake.params.planning_horizons
         )
     ]
 

--- a/scripts/build_population_layouts.py
+++ b/scripts/build_population_layouts.py
@@ -49,10 +49,7 @@ if __name__ == "__main__":
 
     # Filter for the year used in the workflow
     urban_percent_df = urban_percent_df.loc[
-        (
-            urban_percent_df["Year"]
-            == snakemake.params.planning_horizons
-        )
+        (urban_percent_df["Year"] == snakemake.params.planning_horizons)
     ]
 
     # Filter for urban percent column


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

This PR is part of adding Params to all Rules in Snakemake under Issue https://github.com/pypsa-meets-earth/pypsa-earth-sec/issues/330

The following Rules are already done including the work done in this PR:

- [x] add_export.py
- [x] build_base_energy_totals.py
- [x] build_base_industry_totals.py
- [x] build_clustered_population_layouts.py -> _(Had no changes to be done)_
- [x] build_cop_profiles.py
- [x] build_heat_demand.py
- [x] build_industrial_database.py -> _(Had no changes to be done)_
- [x] build_industrial_distribution_key.py
- [x] build_industry_demand.py
- [x] build_population_layouts.py
- [x] build_ship_profile.py
- [x] build_solar_thermal_profiles.py
- [x] build_temperature_profiles.py
- [x] copy_config.py
- [x] helpers.py -> _(Had no changes to be done)_
- [x] make_summary.py
- [x] override_respot.py
plot_network.py
plot_network_eur.py
plot_summary.py
- [x] prepare_airports.py
- [x] prepare_db.py
- [x] prepare_energy_totals.py
- [x] prepare_gas_network.py
prepare_heat_data.py
- [x] prepare_ports.py -> _(Had no changes to be done)_
prepare_sector_network.py
prepare_transport_data.py
- [x] prepare_transport_data_input.py -> _(Had no changes to be done)_
- [x] prepare_urban_percent.py -> _(Had no changes to be done)_
solve_network.py

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.






