### PR TITLE
Fix emission bug

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1068,7 +1068,7 @@ def add_aviation(n, cost):
             airports["p_set"].sum()
             * domestic_to_total
             * costs.at["oil", "CO2 intensity"]
-        )
+        ).item()
 
     n.add(
         "Load",
@@ -1398,7 +1398,7 @@ def add_shipping(n, costs):
                 ports["p_set"].sum()
                 * domestic_to_total
                 * costs.at["oil", "CO2 intensity"]
-            )
+            ).item()
 
         n.add(
             "Load",
@@ -1630,9 +1630,11 @@ def add_industry(n, costs):
         spatial.nodes,
         suffix=" low-temperature heat for industry",
         bus=[
-            node + " urban central heat"
-            if node + " urban central heat" in n.buses.index
-            else node + " services urban decentral heat"
+            (
+                node + " urban central heat"
+                if node + " urban central heat" in n.buses.index
+                else node + " services urban decentral heat"
+            )
             for node in spatial.nodes
         ],
         carrier="low-temperature heat for industry",

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1068,7 +1068,7 @@ def add_aviation(n, cost):
             airports["p_set"].sum()
             * domestic_to_total
             * costs.at["oil", "CO2 intensity"]
-        ).item()
+        ).sum()
 
     n.add(
         "Load",
@@ -1398,7 +1398,7 @@ def add_shipping(n, costs):
                 ports["p_set"].sum()
                 * domestic_to_total
                 * costs.at["oil", "CO2 intensity"]
-            ).item()
+            ).sum()
 
         n.add(
             "Load",

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2378,7 +2378,7 @@ def add_services(n, costs):
     )
 
     # TODO check with different snapshot settings
-    co2 = p_set_gas.sum(axis=1).mean() * costs.at["gas", "CO2 intensity"] * 8760
+    co2 = p_set_gas.sum(axis=1).mean() * costs.at["gas", "CO2 intensity"]
 
     n.add(
         "Load",
@@ -2577,7 +2577,7 @@ def add_residential(n, costs):
     )
 
     # TODO: check 8760 compatibility with different snapshot settings
-    co2 = p_set_gas.sum(axis=1).mean() * costs.at["gas", "CO2 intensity"] * 8760
+    co2 = p_set_gas.sum(axis=1).mean() * costs.at["gas", "CO2 intensity"]
 
     n.add(
         "Load",


### PR DESCRIPTION
### Change 1:
When modeling shipping and aviation excluding international bunker fuels, it was discovered that the corresponding emission columns in the loads dataframe contained NaN values. This issue arose from passing a pandas Series instead of a scalar when adding the load component, specifically in lines 1078 and 1408 of `prepare_sector_network.py`.

### Change 2:
The multiplication of the p_set-value for residential and services gas emissions with the scalar 8760 had to be removed, as the value must correspond to the hourly emission load, as is set for every hour of the dynamic dataframe.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
