### PR TITLE
Full load hour classes for custom RES potentials

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -284,7 +284,7 @@ rule prepare_res_potentials:
         ),
     output:
         **{
-            f"{tech}_{year}_{discountrate}_potential_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_potential_s{simpl}_{clusters}.csv"
+            f"{tech}_{year}_{discountrate}_potential_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_potential_s{{simpl}}_{{clusters}}.csv"
             for tech in config["custom_data"]["renewables"]
             for year in config["scenario"]["planning_horizons"]
             for discountrate in config["costs"]["discountrate"]
@@ -292,7 +292,7 @@ rule prepare_res_potentials:
             for clusters in config["scenario"]["clusters"]
         },
         **{
-            f"{tech}_{year}_{discountrate}_installable_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_installable_s{simpl}_{clusters}.csv"
+            f"{tech}_{year}_{discountrate}_installable_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_installable_s{{simpl}}_{{clusters}}.csv"
             for tech in config["custom_data"]["renewables"]
             for year in config["scenario"]["planning_horizons"]
             for discountrate in config["costs"]["discountrate"]

--- a/Snakefile
+++ b/Snakefile
@@ -284,7 +284,7 @@ rule prepare_res_potentials:
         ),
     output:
         **{
-            f"{tech}_{year}_{discountrate}_potential_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_potential_s{{simpl}}_{{clusters}}.csv"
+            f"{tech}_{year}_{discountrate}_potential_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_potential_s{simpl}_{clusters}.csv"
             for tech in config["custom_data"]["renewables"]
             for year in config["scenario"]["planning_horizons"]
             for discountrate in config["costs"]["discountrate"]
@@ -292,7 +292,7 @@ rule prepare_res_potentials:
             for clusters in config["scenario"]["clusters"]
         },
         **{
-            f"{tech}_{year}_{discountrate}_installable_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_installable_s{{simpl}}_{{clusters}}.csv"
+            f"{tech}_{year}_{discountrate}_installable_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_installable_s{simpl}_{clusters}.csv"
             for tech in config["custom_data"]["renewables"]
             for year in config["scenario"]["planning_horizons"]
             for discountrate in config["costs"]["discountrate"]

--- a/config.bright.yaml
+++ b/config.bright.yaml
@@ -6,7 +6,7 @@ summary_dir: results/
 costs_dir: data/ #TODO change to the equivalent of technology data
 
 run:
-  name: 0904_integrate_enertile
+  name: 0917_integrate_enertile_flh_classes
   name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
   shared_cutouts: true  # set to true to share the default cutout(s) across runs
                         # Note: value false requires build_cutout to be enabled
@@ -491,6 +491,7 @@ plotting:
     onwind: "dodgerblue"
     onwind2: "dodgerblue"
     onwind3: "dodgerblue"
+    onwind4: "dodgerblue"
     onshore wind: "#235ebc"
     offwind: "#6895dd"
     offshore wind: "#6895dd"

--- a/scripts/override_respot.py
+++ b/scripts/override_respot.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import logging
 import os
 from itertools import dropwhile
 from types import SimpleNamespace
@@ -10,7 +11,6 @@ import pypsa
 import pytz
 import xarray as xr
 from helpers import mock_snakemake, override_component_attrs, sets_path_to_root
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/override_respot.py
+++ b/scripts/override_respot.py
@@ -10,6 +10,9 @@ import pypsa
 import pytz
 import xarray as xr
 from helpers import mock_snakemake, override_component_attrs, sets_path_to_root
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def override_values(tech, year, dr, simpl, clusters):
@@ -23,24 +26,27 @@ def override_values(tech, year, dr, simpl, clusters):
         parse_dates=True,
     ).filter(buses, axis=1)
 
-    custom_res = (
-        pd.read_csv(
-            snakemake.input[
-                "custom_res_ins_{0}_{1}_{2}_s{3}_{4}".format(
-                    tech, year, dr, simpl, clusters
-                )
-            ],
-            index_col=0,
-        )
-        .loc[buses]
-        .reset_index()
+    custom_res = pd.read_csv(
+        snakemake.input[
+            "custom_res_ins_{0}_{1}_{2}_s{3}_{4}".format(
+                tech, year, dr, simpl, clusters
+            )
+        ],
     )
 
-    custom_res["Generator"] = custom_res["Generator"].apply(lambda x: x + " " + tech)
-    custom_res = custom_res.set_index("Generator")
+    custom_res.index = custom_res["Generator"] + " " + tech
+    custom_res_t.columns = custom_res_t.columns + " " + tech
 
     if tech.replace("-", " ") in n.generators.carrier.unique():
         to_drop = n.generators[n.generators.carrier == tech].index
+        custom_res.loc[to_drop, "installedcapacity"] = n.generators.loc[
+            to_drop, "p_nom"
+        ]
+        mask = custom_res["installedcapacity"] > custom_res.p_nom_max
+        if mask.any():
+            logger.info(
+                f"Installed capacities exceed maximum installable capacities for {tech} at nodes {custom_res.loc[mask].index}."
+            )
         n.mremove("Generator", to_drop)
 
     if snakemake.wildcards["planning_horizons"] == 2050:
@@ -57,19 +63,18 @@ def override_values(tech, year, dr, simpl, clusters):
 
     n.madd(
         "Generator",
-        buses,
-        " " + tech,
-        bus=buses,
+        custom_res.index,
+        bus=custom_res["Generator"],
         carrier=tech,
         p_nom_extendable=True,
-        p_nom_max=custom_res["p_nom_max"].values,
+        p_nom_max=custom_res["p_nom_max"],
         # weight=ds["weight"].to_pandas(),
         # marginal_cost=custom_res["fixedomEuroPKW"].values * 1000,
-        capital_cost=custom_res["annualcostEuroPMW"].values,
+        capital_cost=custom_res["annualcostEuroPMW"],
         efficiency=1.0,
         p_max_pu=custom_res_t,
-        lifetime=custom_res["lifetime"][0],
-        p_nom_min=existing_res,
+        lifetime=custom_res["lifetime"],
+        p_nom_min=custom_res["installedcapacity"],
     )
 
 

--- a/scripts/prepare_res_potentials.py
+++ b/scripts/prepare_res_potentials.py
@@ -30,7 +30,7 @@ def calculate_flh_classes(group):
     n = len(group)
     if n < 4:
         bins = [i / n for i in range(n + 1)]
-        labels = [f"Q{i+3}" for i in range(n)]
+        labels = [f"Q{i}" for i in range(5 - n, 5)]
     else:
         bins = [0, 0.3, 0.6, 0.9, 1.0]
         labels = ["Q1", "Q2", "Q3", "Q4"]
@@ -171,17 +171,13 @@ def prepare_enertile(df, df_t):
         numeric_only=True
     )
 
-    # if technology == "onwind":
-    #     bins = [-float("inf"), 1, 2, float("inf")]
-    #     labels = ["very good", "good", "remaining"]
-    # else:
-    #     bins = [-float("inf"), float("inf")]
-    #     labels = ["very good"]
-
     df = df.groupby(["Generator", "step", "simyear"], as_index=False).mean()
-    df = df.groupby(["Generator", "simyear"], as_index=False).apply(
-        calculate_flh_classes
-    )
+    if technology == "solar":
+        df["flh_class"] = "Q4"
+    else:
+        df = df.groupby(["Generator", "simyear"], as_index=False).apply(
+            calculate_flh_classes
+        )
 
     df.set_index(["Generator", "step", "simyear"], inplace=True)
     df_t.set_index(["region", "step", "simyear"], inplace=True)


### PR DESCRIPTION
This PR modifies the preprocessing and overriding process for custom renewable data used in BRIGHT, focusing specifically on onshore wind potentials.

The onshore wind input data have been cleaned so that the full load hours of each data point correlate with its integer step label. Instead of categorizing data points by their steps, the full load hours now determine their assignment to a potential class (onwind, onwind2, onwind3, onwind4). Generally, only two potential classes are used to represent onshore wind potentials (onwind, onwind2), except for the four most favorable regions of the country (BRA_6_1, BRA_17_1, BRA_20_1, BRA_21_1), which are represented by all four classes.

As a result of the new aggregation method, the number of steps serving as the basis for a potential class can vary by location. Currently, the mapping between data points and potential classes follows the quantile distribution:

    0 ≤ onwind4 < 0.4 ≤ onwind3 < 0.6 ≤ onwind2 < 0.9 ≤ onwind ≤ 1

The overriding process only occurs at locations with a p_nom_max > 0. Existing capacities retrieved by PowerPlantMatching are set as the p_nom_min for the best potential classes.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.bright.yaml`

