### PR TITLE
Minor adjustments

### DIFF
--- a/config.bright.yaml
+++ b/config.bright.yaml
@@ -520,6 +520,7 @@ plotting:
     natural gas: brown
     SMR: '#4F4F2F'
     oil: '#B5A642'
+    oil EOP: '#B5A677'
     oil boiler: '#B5A677'
     lines: k
     transmission lines: k

--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -742,6 +742,7 @@ def get_last_commit_message(path):
             subprocess.check_output(
                 ["git", "log", "-n", "1", "--pretty=format:%H %s"],
                 stderr=subprocess.STDOUT,
+                shell=True,
             )
             .decode()
             .strip()

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2737,8 +2737,8 @@ if __name__ == "__main__":
     # clustering of regions must be double checked.. refer to regions onshore
 
     # Change the carrier "oil" so that it
-    n.carriers = n.carriers.rename({"oil": "Oil EOP"})
-    n.generators["carrier"].replace("oil", "Oil EOP", inplace=True)
+    n.carriers = n.carriers.rename({"oil": "oil EOP"})
+    n.generators["carrier"].replace("oil", "oil EOP", inplace=True)
 
     # Add location. TODO: move it into pypsa-earth
     n.buses.location = n.buses.index


### PR DESCRIPTION
This PR introduces two minor changes:
1. "Oil EOP" technology is renamed to "oil EOP" for consistency reasons. Furthermore, the technology's tech_color is added in `config.bright.yaml`.
2. In the script `helpers.py` the argument `shell` of the function call `subprocess.check_output()` within the helper function `get_last_commit_message()` is set to `True`, to hotfix the workflow operation on the HPC. 
