### PR TITLE
adapt default trasnport demand for final energy

### DIFF
--- a/scripts/prepare_transport_data.py
+++ b/scripts/prepare_transport_data.py
@@ -138,23 +138,23 @@ def prepare_transport_data(n):
 
     # divide out the heating/cooling demand from ICE totals
     # and multiply back in the heating/cooling demand for EVs
-    ice_correction = (transport_shape * (1 + dd_ICE)).sum() / transport_shape.sum()
+    ice_correction = (transport_shape * (1 + dd_ICE)).sum() / transport_shape.sum() # currently not used same for dd_EV
 
-    if snakemake.config["custom_data"]["transport_demand"]:
-        energy_totals_transport = nodal_energy_totals["total road"]
+    # if snakemake.config["custom_data"]["transport_demand"]:
+    energy_totals_transport = nodal_energy_totals["total road"]
 
-        transport = transport_shape.multiply(energy_totals_transport) * 1e6 * Nyears
-    else:
-        energy_totals_transport = (
-            nodal_energy_totals["total road"]
-            + nodal_energy_totals["total rail"]
-            - nodal_energy_totals["electricity rail"]
-        )
-        transport = (
-            (transport_shape.multiply(energy_totals_transport) * 1e6 * Nyears)
-            .divide(efficiency_gain * ice_correction)
-            .multiply(1 + dd_EV)
-        )
+    transport = transport_shape.multiply(energy_totals_transport) * 1e6 * Nyears
+    # else:
+    #     energy_totals_transport = (
+    #         nodal_energy_totals["total road"]
+    #         + nodal_energy_totals["total rail"]
+    #         - nodal_energy_totals["electricity rail"]
+    #     )
+    #     transport = (
+    #         (transport_shape.multiply(energy_totals_transport) * 1e6 * Nyears)
+    #         .divide(efficiency_gain * ice_correction)
+    #         .multiply(1 + dd_EV)
+    #     )
 
     # derive plugged-in availability for PKW's (cars)
 
@@ -205,8 +205,8 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "prepare_transport_data",
             simpl="",
-            clusters="74",
-            demand="AB",
+            clusters="11",
+            demand="NI",
             planning_horizons=2030,
         )
 


### PR DESCRIPTION
This PR removes the rail transport from the land transport as it is now added separately in prepare_sector_network.py

It also disregards the old way of including the efficiency gains, as it has now been replaced by a new way using the efficiency_gains.csv parameter file. Finally, it removes the ice_correction factor which is legacy code from PyPSA-Eur and should be revised