### PR TITLE
Track biofuel demand in transport sector using BtL

### DIFF
--- a/config.bright_BI.yaml
+++ b/config.bright_BI.yaml
@@ -653,3 +653,5 @@ plotting:
     high-temp electrolysis: "magenta"
     oil pipeline: "grey"
     agriculture biomass: "green"
+    biomass to liquid: "green"
+

--- a/config.bright_BI.yaml
+++ b/config.bright_BI.yaml
@@ -363,30 +363,9 @@ sector:
     DE_2050: 0.593
 
   bio_transport_share: # 1 means all EVs  # This leads to problems when non-zero HERE
-    BU_2030: 0.00
-    BI_2030: 0.002
-    GH_2030: 0.002
-    DE_2030: 0.005
-    AP_2030: 0.075
-    NZ_2030: 0.13
-    DF_2030: 0.01
-    AB_2030: 0.01
-    BU_2050: 0.00
-    AP_2050: 0.42
-    NZ_2050: 0.68
-    DF_2050: 0.011
-    BI_2035: 0.50
-    GH_2035: 0.33
-    DE_2035: 0.053
-    BI_2040: 0.044
-    GH_2040: 0.092
-    DE_2040: 0.152
-    BI_2045: 0.066
-    GH_2045: 0.197
-    DE_2045: 0.332
-    BI_2050: 0.090
-    GH_2050: 0.320
-    DE_2050: 0.593
+    BI_2035: 0.356
+    GH_2035: 0.237
+    DE_2035: 0.253
 
   co2_network: true
   co2_sequestration_potential: 70 #MtCO2/a sequestration potential for Europe

--- a/config.bright_BI_ref.yaml
+++ b/config.bright_BI_ref.yaml
@@ -363,30 +363,9 @@ sector:
     DE_2050: 0.593
 
   bio_transport_share: # 1 means all EVs  # This leads to problems when non-zero HERE
-    BU_2030: 0.00
-    BI_2030: 0.002
-    GH_2030: 0.002
-    DE_2030: 0.005
-    AP_2030: 0.075
-    NZ_2030: 0.13
-    DF_2030: 0.01
-    AB_2030: 0.01
-    BU_2050: 0.00
-    AP_2050: 0.42
-    NZ_2050: 0.68
-    DF_2050: 0.011
-    BI_2035: 0.50
-    GH_2035: 0.33
-    DE_2035: 0.053
-    BI_2040: 0.044
-    GH_2040: 0.092
-    DE_2040: 0.152
-    BI_2045: 0.066
-    GH_2045: 0.197
-    DE_2045: 0.332
-    BI_2050: 0.090
-    GH_2050: 0.320
-    DE_2050: 0.593
+    BI_2035: 0.356
+    GH_2035: 0.237
+    DE_2035: 0.253
 
   co2_network: true
   co2_sequestration_potential: 70 #MtCO2/a sequestration potential for Europe

--- a/config.bright_BI_ref.yaml
+++ b/config.bright_BI_ref.yaml
@@ -6,7 +6,7 @@ summary_dir: results/
 costs_dir: data/ #TODO change to the equivalent of technology data
 
 run:
-  name: TEST_Octoober9th_BI_20kTWkmH2net_oilpipeline_dac_adaptedemissionICEMORE_co2seq70_3H_newscenario_correctPorts_addBioTransport
+  name: 20241021_biofuels
   name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
   shared_cutouts: true  # set to true to share the default cutout(s) across runs
                         # Note: value false requires build_cutout to be enabled
@@ -88,7 +88,6 @@ custom_data:
   add_existing: false
   custom_sectors: false
   gas_network: false # If "True" then a custom .csv file must be placed in "resources/custom_data/pipelines.csv" , If "False" the user can choose btw "greenfield" or Model built-in datasets. Please refer to ["sector"] below.
-  biomass_to_oil_mobility: 0.0
   rename_industry_carriers: {"Electricity": "electricity", "Biofuels": "solid biomass", "Heat": "low-temperature heat", "Natural Gas": "gas", "Coal": "coal", "Hydrogen": "hydrogen", "Oil": "oil"}
 
 costs: # Costs used in PyPSA-Earth-Sec. Year depends on the wildcard planning_horizon in the scenario section
@@ -263,6 +262,7 @@ sector:
   biomass_transport_default_cost: 0.1 #EUR/km/MWh
   solid_biomass_potential: 3604 # 4805 TWh/a for all bioenergy sources according to Welfle (2017), 75% solid, 0.28% gaseous according to IEA (2021)
   biogas_potential: 13.5 # TWh/a, Potential of whole modelled area
+  biomass_to_liquid: True
 
   efficiency_heat_oil_to_elec: 0.9
   efficiency_heat_biomass_to_elec: 0.9

--- a/config.bright_DE.yaml
+++ b/config.bright_DE.yaml
@@ -653,3 +653,4 @@ plotting:
     high-temp electrolysis: "magenta"
     oil pipeline: "grey"
     agriculture biomass: "green"
+    biomass to liquid: "green"

--- a/config.bright_DE.yaml
+++ b/config.bright_DE.yaml
@@ -6,7 +6,7 @@ summary_dir: results/
 costs_dir: data/ #TODO change to the equivalent of technology data
 
 run:
-  name: 092524_test
+  name: 20241021_biofuels
   name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
   shared_cutouts: true  # set to true to share the default cutout(s) across runs
                         # Note: value false requires build_cutout to be enabled
@@ -28,19 +28,19 @@ scenario:
   opts:
   - "Co2L"
   sopts:
-  - "8H"
+  - "3H"
   demand:
   - "DE" # BI/DE/GH
 
 policy_config:
   hydrogen:
-    temporal_matching: "no_res_matching" #either "h2_yearly_matching", "h2_monthly_matching", "no_res_matching"
+    temporal_matching: "h2_monthly_matching" #either "h2_yearly_matching", "h2_monthly_matching", "no_res_matching"
     spatial_matching: false
     additionality: true # RE electricity is equal to the amount required for additional hydrogen export compared to the 0 export case ("reference_case")
     allowed_excess: 1.0
     is_reference: false # Whether or not this network is a reference case network, relevant only if additionality is _true_
     remove_h2_load: false #Whether or not to remove the h2 load from the network, relevant only if is_reference is _true_
-    path_to_ref: "" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
+    path_to_ref: "/nimble/home/haz43975/pypsa-earth-sec/results/20241021_biofuels/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.071_DE_0export.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
     re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
 
 clustering_options:
@@ -64,7 +64,7 @@ fossil_reserves:
 
 
 export:
-  h2export: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100] # Yearly export demand in TWh
+  h2export: [200] #[10,20,30,40,50,60,70,80,90,100] # Yearly export demand in TWh
   store: false # [True, False] # specifies wether an export store to balance demand is implemented
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
   export_profile: "constant" # use "ship" or "constant"
@@ -88,7 +88,6 @@ custom_data:
   add_existing: false
   custom_sectors: false
   gas_network: false # If "True" then a custom .csv file must be placed in "resources/custom_data/pipelines.csv" , If "False" the user can choose btw "greenfield" or Model built-in datasets. Please refer to ["sector"] below.
-
   rename_industry_carriers: {"Electricity": "electricity", "Biofuels": "solid biomass", "Heat": "low-temperature heat", "Natural Gas": "gas", "Coal": "coal", "Hydrogen": "hydrogen", "Oil": "oil"}
 
 costs: # Costs used in PyPSA-Earth-Sec. Year depends on the wildcard planning_horizon in the scenario section
@@ -190,8 +189,8 @@ sector:
     network_data_GGIT_status: ['Construction', 'Operating', 'Idle', 'Shelved', 'Mothballed', 'Proposed']
   hydrogen:
     network: true
-    network_limit: 10000 #GWkm
-    network_routes: gas # "gas or "greenfield". If "gas"  ->  the network data are fetched from ["sector"]["gas"]["network_data"]. If "greenfield"  -> the network follows the topology of electrical transmission lines
+    network_limit: 25000 #GWkm
+    network_routes: greenfield # "gas or "greenfield". If "gas"  ->  the network data are fetched from ["sector"]["gas"]["network_data"]. If "greenfield"  -> the network follows the topology of electrical transmission lines
     gas_network_repurposing: true # If true -> ["sector"]["gas"]["network"] is automatically false
     underground_storage: false
     hydrogen_colors: false
@@ -263,6 +262,7 @@ sector:
   biomass_transport_default_cost: 0.1 #EUR/km/MWh
   solid_biomass_potential: 3604 # 4805 TWh/a for all bioenergy sources according to Welfle (2017), 75% solid, 0.28% gaseous according to IEA (2021)
   biogas_potential: 13.5 # TWh/a, Potential of whole modelled area
+  biomass_to_liquid: True
 
   efficiency_heat_oil_to_elec: 0.9
   efficiency_heat_biomass_to_elec: 0.9
@@ -284,6 +284,19 @@ sector:
       Co2L0.10: 0.80
       Co2L0.00: 0.88
     land_transport_fuel_cell_share:
+      Co2L2.0: 0.01
+      Co2L1.0: 0.01
+      Co2L0.90: 0.01
+      Co2L0.80: 0.01
+      Co2L0.70: 0.01
+      Co2L0.60: 0.01
+      Co2L0.50: 0.01
+      Co2L0.40: 0.01
+      Co2L0.30: 0.01
+      Co2L0.20: 0.01
+      Co2L0.10: 0.01
+      Co2L0.00: 0.01
+    bio_transport_share:
       Co2L2.0: 0.01
       Co2L1.0: 0.01
       Co2L0.90: 0.01
@@ -349,8 +362,34 @@ sector:
     GH_2050: 0.320
     DE_2050: 0.593
 
-  co2_network: false
-  co2_sequestration_potential: 0 #MtCO2/a sequestration potential for Europe
+  bio_transport_share: # 1 means all EVs  # This leads to problems when non-zero HERE
+    BU_2030: 0.00
+    BI_2030: 0.002
+    GH_2030: 0.002
+    DE_2030: 0.005
+    AP_2030: 0.075
+    NZ_2030: 0.13
+    DF_2030: 0.01
+    AB_2030: 0.01
+    BU_2050: 0.00
+    AP_2050: 0.42
+    NZ_2050: 0.68
+    DF_2050: 0.011
+    BI_2035: 0.50
+    GH_2035: 0.33
+    DE_2035: 0.053
+    BI_2040: 0.044
+    GH_2040: 0.092
+    DE_2040: 0.152
+    BI_2045: 0.066
+    GH_2045: 0.197
+    DE_2045: 0.332
+    BI_2050: 0.090
+    GH_2050: 0.320
+    DE_2050: 0.593
+
+  co2_network: true
+  co2_sequestration_potential: 70 #MtCO2/a sequestration potential for Europe
   co2_sequestration_cost: 10 #EUR/tCO2 for sequestration of CO2
   hydrogen_underground_storage: false
   shipping_hydrogen_liquefaction: false
@@ -359,8 +398,11 @@ sector:
   shipping_hydrogen_share: #1.0
     BU_2030: 0.00
     BI_2030: 0.00
+    BI_2035: 0.014
     GH_2030: 0.00
+    GH_2035: 0.014
     DE_2030: 0.00
+    DE_2035: 0.014
     AP_2030: 0.00
     NZ_2030: 0.10
     DF_2030: 0.05
@@ -377,7 +419,7 @@ sector:
   marginal_cost_storage: 0
   methanation: true
   helmeth: true
-  dac: false
+  dac: true
   SMR: true
   SMR CC: true
   cc_fraction: 0.9
@@ -630,3 +672,5 @@ plotting:
     biomass EOP: "green"
     biomass: "green"
     high-temp electrolysis: "magenta"
+    oil pipeline: "grey"
+    agriculture biomass: "green"

--- a/config.bright_DE.yaml
+++ b/config.bright_DE.yaml
@@ -363,30 +363,9 @@ sector:
     DE_2050: 0.593
 
   bio_transport_share: # 1 means all EVs  # This leads to problems when non-zero HERE
-    BU_2030: 0.00
-    BI_2030: 0.002
-    GH_2030: 0.002
-    DE_2030: 0.005
-    AP_2030: 0.075
-    NZ_2030: 0.13
-    DF_2030: 0.01
-    AB_2030: 0.01
-    BU_2050: 0.00
-    AP_2050: 0.42
-    NZ_2050: 0.68
-    DF_2050: 0.011
-    BI_2035: 0.50
-    GH_2035: 0.33
-    DE_2035: 0.053
-    BI_2040: 0.044
-    GH_2040: 0.092
-    DE_2040: 0.152
-    BI_2045: 0.066
-    GH_2045: 0.197
-    DE_2045: 0.332
-    BI_2050: 0.090
-    GH_2050: 0.320
-    DE_2050: 0.593
+    BI_2035: 0.356
+    GH_2035: 0.237
+    DE_2035: 0.253
 
   co2_network: true
   co2_sequestration_potential: 70 #MtCO2/a sequestration potential for Europe

--- a/config.bright_DE.yaml
+++ b/config.bright_DE.yaml
@@ -640,4 +640,3 @@ plotting:
     oil pipeline: "grey"
     agriculture biomass: "green"
     biomass to liquid: "green"
-

--- a/config.bright_DE_ref.yaml
+++ b/config.bright_DE_ref.yaml
@@ -658,4 +658,3 @@ plotting:
     oil pipeline: "grey"
     agriculture biomass: "green"
     biomass to liquid: "green"
-

--- a/config.bright_DE_ref.yaml
+++ b/config.bright_DE_ref.yaml
@@ -653,3 +653,4 @@ plotting:
     high-temp electrolysis: "magenta"
     oil pipeline: "grey"
     agriculture biomass: "green"
+    biomass to liquid: "green"

--- a/config.bright_DE_ref.yaml
+++ b/config.bright_DE_ref.yaml
@@ -363,30 +363,9 @@ sector:
     DE_2050: 0.593
 
   bio_transport_share: # 1 means all EVs  # This leads to problems when non-zero HERE
-    BU_2030: 0.00
-    BI_2030: 0.002
-    GH_2030: 0.002
-    DE_2030: 0.005
-    AP_2030: 0.075
-    NZ_2030: 0.13
-    DF_2030: 0.01
-    AB_2030: 0.01
-    BU_2050: 0.00
-    AP_2050: 0.42
-    NZ_2050: 0.68
-    DF_2050: 0.011
-    BI_2035: 0.50
-    GH_2035: 0.33
-    DE_2035: 0.053
-    BI_2040: 0.044
-    GH_2040: 0.092
-    DE_2040: 0.152
-    BI_2045: 0.066
-    GH_2045: 0.197
-    DE_2045: 0.332
-    BI_2050: 0.090
-    GH_2050: 0.320
-    DE_2050: 0.593
+    BI_2035: 0.356
+    GH_2035: 0.237
+    DE_2035: 0.253
 
   co2_network: true
   co2_sequestration_potential: 70 #MtCO2/a sequestration potential for Europe

--- a/config.bright_DE_ref.yaml
+++ b/config.bright_DE_ref.yaml
@@ -30,7 +30,7 @@ scenario:
   sopts:
   - "3H"
   demand:
-  - "BI" # BI/DE/GH
+  - "DE" # BI/DE/GH
 
 policy_config:
   hydrogen:
@@ -38,9 +38,9 @@ policy_config:
     spatial_matching: false
     additionality: true # RE electricity is equal to the amount required for additional hydrogen export compared to the 0 export case ("reference_case")
     allowed_excess: 1.0
-    is_reference: false # Whether or not this network is a reference case network, relevant only if additionality is _true_
+    is_reference: true # Whether or not this network is a reference case network, relevant only if additionality is _true_
     remove_h2_load: false #Whether or not to remove the h2 load from the network, relevant only if is_reference is _true_
-    path_to_ref: "/nimble/home/haz43975/pypsa-earth-sec/results/20241021_biofuels/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.071_BI_0export.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
+    path_to_ref: "" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
     re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
 
 clustering_options:
@@ -64,7 +64,7 @@ fossil_reserves:
 
 
 export:
-  h2export: [200] #[10,20,30,40,50,60,70,80,90,100] # Yearly export demand in TWh
+  h2export: [0] #[10,20,30,40,50,60,70,80,90,100] # Yearly export demand in TWh
   store: false # [True, False] # specifies wether an export store to balance demand is implemented
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
   export_profile: "constant" # use "ship" or "constant"

--- a/config.bright_GH.yaml
+++ b/config.bright_GH.yaml
@@ -6,7 +6,7 @@ summary_dir: results/
 costs_dir: data/ #TODO change to the equivalent of technology data
 
 run:
-  name: TEST_Octoober9th_GH_20kTWkmH2net_oilpipeline_dac_adaptedemissionICEMORE_co2seq70_3H_newscenario_correctPorts
+  name: 20241021_biofuels
   name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
   shared_cutouts: true  # set to true to share the default cutout(s) across runs
                         # Note: value false requires build_cutout to be enabled
@@ -264,6 +264,7 @@ sector:
   biomass_transport_default_cost: 0.1 #EUR/km/MWh
   solid_biomass_potential: 3604 # 4805 TWh/a for all bioenergy sources according to Welfle (2017), 75% solid, 0.28% gaseous according to IEA (2021)
   biogas_potential: 13.5 # TWh/a, Potential of whole modelled area
+  biomass_to_liquid: True
 
   efficiency_heat_oil_to_elec: 0.9
   efficiency_heat_biomass_to_elec: 0.9
@@ -285,6 +286,19 @@ sector:
       Co2L0.10: 0.80
       Co2L0.00: 0.88
     land_transport_fuel_cell_share:
+      Co2L2.0: 0.01
+      Co2L1.0: 0.01
+      Co2L0.90: 0.01
+      Co2L0.80: 0.01
+      Co2L0.70: 0.01
+      Co2L0.60: 0.01
+      Co2L0.50: 0.01
+      Co2L0.40: 0.01
+      Co2L0.30: 0.01
+      Co2L0.20: 0.01
+      Co2L0.10: 0.01
+      Co2L0.00: 0.01
+    bio_transport_share:
       Co2L2.0: 0.01
       Co2L1.0: 0.01
       Co2L0.90: 0.01
@@ -339,6 +353,32 @@ sector:
     DF_2050: 0.011
     BI_2035: 0.014
     GH_2035: 0.031
+    DE_2035: 0.053
+    BI_2040: 0.044
+    GH_2040: 0.092
+    DE_2040: 0.152
+    BI_2045: 0.066
+    GH_2045: 0.197
+    DE_2045: 0.332
+    BI_2050: 0.090
+    GH_2050: 0.320
+    DE_2050: 0.593
+
+  bio_transport_share: # 1 means all EVs  # This leads to problems when non-zero HERE
+    BU_2030: 0.00
+    BI_2030: 0.002
+    GH_2030: 0.002
+    DE_2030: 0.005
+    AP_2030: 0.075
+    NZ_2030: 0.13
+    DF_2030: 0.01
+    AB_2030: 0.01
+    BU_2050: 0.00
+    AP_2050: 0.42
+    NZ_2050: 0.68
+    DF_2050: 0.011
+    BI_2035: 0.50
+    GH_2035: 0.33
     DE_2035: 0.053
     BI_2040: 0.044
     GH_2040: 0.092

--- a/config.bright_GH.yaml
+++ b/config.bright_GH.yaml
@@ -653,3 +653,4 @@ plotting:
     high-temp electrolysis: "magenta"
     oil pipeline: "grey"
     agriculture biomass: "green"
+    biomass to liquid: "green"

--- a/config.bright_GH.yaml
+++ b/config.bright_GH.yaml
@@ -365,30 +365,9 @@ sector:
     DE_2050: 0.593
 
   bio_transport_share: # 1 means all EVs  # This leads to problems when non-zero HERE
-    BU_2030: 0.00
-    BI_2030: 0.002
-    GH_2030: 0.002
-    DE_2030: 0.005
-    AP_2030: 0.075
-    NZ_2030: 0.13
-    DF_2030: 0.01
-    AB_2030: 0.01
-    BU_2050: 0.00
-    AP_2050: 0.42
-    NZ_2050: 0.68
-    DF_2050: 0.011
-    BI_2035: 0.50
-    GH_2035: 0.33
-    DE_2035: 0.053
-    BI_2040: 0.044
-    GH_2040: 0.092
-    DE_2040: 0.152
-    BI_2045: 0.066
-    GH_2045: 0.197
-    DE_2045: 0.332
-    BI_2050: 0.090
-    GH_2050: 0.320
-    DE_2050: 0.593
+    BI_2035: 0.356
+    GH_2035: 0.237
+    DE_2035: 0.253
 
   co2_network: true
   co2_sequestration_potential: 70 #MtCO2/a sequestration potential for Europe

--- a/config.bright_GH.yaml
+++ b/config.bright_GH.yaml
@@ -643,4 +643,3 @@ plotting:
     oil pipeline: "grey"
     agriculture biomass: "green"
     biomass to liquid: "green"
-

--- a/config.bright_GH_ref.yaml
+++ b/config.bright_GH_ref.yaml
@@ -6,7 +6,7 @@ summary_dir: results/
 costs_dir: data/ #TODO change to the equivalent of technology data
 
 run:
-  name: TEST_Octoober9th_GH_20kTWkmH2net_oilpipeline_dac_adaptedemissionICEMORE_co2seq70_3H_newscenario_correctPorts
+  name: 20241021_biofuels
   name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
   shared_cutouts: true  # set to true to share the default cutout(s) across runs
                         # Note: value false requires build_cutout to be enabled
@@ -264,6 +264,7 @@ sector:
   biomass_transport_default_cost: 0.1 #EUR/km/MWh
   solid_biomass_potential: 3604 # 4805 TWh/a for all bioenergy sources according to Welfle (2017), 75% solid, 0.28% gaseous according to IEA (2021)
   biogas_potential: 13.5 # TWh/a, Potential of whole modelled area
+  biomass_to_liquid: True
 
   efficiency_heat_oil_to_elec: 0.9
   efficiency_heat_biomass_to_elec: 0.9
@@ -285,6 +286,19 @@ sector:
       Co2L0.10: 0.80
       Co2L0.00: 0.88
     land_transport_fuel_cell_share:
+      Co2L2.0: 0.01
+      Co2L1.0: 0.01
+      Co2L0.90: 0.01
+      Co2L0.80: 0.01
+      Co2L0.70: 0.01
+      Co2L0.60: 0.01
+      Co2L0.50: 0.01
+      Co2L0.40: 0.01
+      Co2L0.30: 0.01
+      Co2L0.20: 0.01
+      Co2L0.10: 0.01
+      Co2L0.00: 0.01
+    bio_transport_share:
       Co2L2.0: 0.01
       Co2L1.0: 0.01
       Co2L0.90: 0.01
@@ -339,6 +353,32 @@ sector:
     DF_2050: 0.011
     BI_2035: 0.014
     GH_2035: 0.031
+    DE_2035: 0.053
+    BI_2040: 0.044
+    GH_2040: 0.092
+    DE_2040: 0.152
+    BI_2045: 0.066
+    GH_2045: 0.197
+    DE_2045: 0.332
+    BI_2050: 0.090
+    GH_2050: 0.320
+    DE_2050: 0.593
+
+  bio_transport_share: # 1 means all EVs  # This leads to problems when non-zero HERE
+    BU_2030: 0.00
+    BI_2030: 0.002
+    GH_2030: 0.002
+    DE_2030: 0.005
+    AP_2030: 0.075
+    NZ_2030: 0.13
+    DF_2030: 0.01
+    AB_2030: 0.01
+    BU_2050: 0.00
+    AP_2050: 0.42
+    NZ_2050: 0.68
+    DF_2050: 0.011
+    BI_2035: 0.50
+    GH_2035: 0.33
     DE_2035: 0.053
     BI_2040: 0.044
     GH_2040: 0.092

--- a/config.bright_GH_ref.yaml
+++ b/config.bright_GH_ref.yaml
@@ -653,3 +653,4 @@ plotting:
     high-temp electrolysis: "magenta"
     oil pipeline: "grey"
     agriculture biomass: "green"
+    biomass to liquid: "green"

--- a/config.bright_GH_ref.yaml
+++ b/config.bright_GH_ref.yaml
@@ -642,4 +642,3 @@ plotting:
     oil pipeline: "grey"
     agriculture biomass: "green"
     biomass to liquid: "green"
-

--- a/config.bright_GH_ref.yaml
+++ b/config.bright_GH_ref.yaml
@@ -365,30 +365,9 @@ sector:
     DE_2050: 0.593
 
   bio_transport_share: # 1 means all EVs  # This leads to problems when non-zero HERE
-    BU_2030: 0.00
-    BI_2030: 0.002
-    GH_2030: 0.002
-    DE_2030: 0.005
-    AP_2030: 0.075
-    NZ_2030: 0.13
-    DF_2030: 0.01
-    AB_2030: 0.01
-    BU_2050: 0.00
-    AP_2050: 0.42
-    NZ_2050: 0.68
-    DF_2050: 0.011
-    BI_2035: 0.50
-    GH_2035: 0.33
-    DE_2035: 0.053
-    BI_2040: 0.044
-    GH_2040: 0.092
-    DE_2040: 0.152
-    BI_2045: 0.066
-    GH_2045: 0.197
-    DE_2045: 0.332
-    BI_2050: 0.090
-    GH_2050: 0.320
-    DE_2050: 0.593
+    BI_2035: 0.356
+    GH_2035: 0.237
+    DE_2035: 0.253
 
   co2_network: true
   co2_sequestration_potential: 70 #MtCO2/a sequestration potential for Europe

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -838,7 +838,8 @@ def add_biomass(n, costs):
             efficiency=costs.at["BtL", "efficiency"],
             efficiency2=-costs.at["solid biomass", "CO2 intensity"]
             + costs.at["BtL", "CO2 stored"],
-            p_nom_extendable=True,
+            p_nom=p_nom,
+            p_nom_extendable=False,
             p_min_pu=p_minmax_pu,
             p_max_pu=p_minmax_pu,
             capital_cost=costs.at["BtL", "fixed"] * costs.at["BtL", "efficiency"],

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -826,9 +826,9 @@ def add_biomass(n, costs):
         p_nom = p_set.max()
         p_minmax_pu = p_set / p_nom
 
-        n.add(
+        n.madd(
             "Link",
-            spatial.biomass.nodes,
+            p_nom.index,
             suffix=" biomass to liquid",
             bus0=spatial.biomass.nodes,
             bus1=spatial.oil.nodes,
@@ -1973,7 +1973,7 @@ def add_land_transport(n, costs):
             * transport[spatial.nodes].sum().sum()
             / 8760
             * costs.at["oil", "CO2 intensity"]
-        ) * snakemake.config["custom_data"]["biomass_to_oil_mobility"]
+        )
 
         n.add(
             "Load",

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -822,7 +822,12 @@ def add_biomass(n, costs):
             demand_sc + "_" + str(investment_year),
         )
         ice_efficiency = options["transport_internal_combustion_efficiency"]
-        p_set = bio_transport_share / ice_efficiency * transport[spatial.nodes]
+        p_set = (
+            bio_transport_share
+            / costs.at["BtL", "efficiency"]
+            / ice_efficiency
+            * transport[spatial.nodes]
+        )
         p_nom = p_set.max()
         p_minmax_pu = p_set / p_nom
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
 This PR introduces the biomass-to-liquid (BtL) link in `prepare_sector_network`. It is implemented to cover exclusively the biofuels demand in the land transport sector. Therefore, the link capacities are dimensioned according to the needs of the transport load. The link operation is fixed by setting `p_min_pu = p_max_pu`.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
