### PR TITLE
Endogenize decision on H2 export quantity

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -52,7 +52,8 @@ wildcard_constraints:
     sopts="[-+a-zA-Z0-9\.\s]*",
     discountrate="[-+a-zA-Z0-9\.\s]*",
     demand="[-+a-zA-Z0-9\.\s]*",
-    h2export="[0-9]+m?|all",
+    h2export="[0-9]+m?|all|endogenous",
+    h2mp="[0-9]+([.,][0-9]+)?|all|endogenous",
     planning_horizons="20[2-9][0-9]|2100",
 
 
@@ -115,7 +116,7 @@ rule solve_all_networks:
     input:
         expand(
             RDIR
-            + "/postnetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export.nc",
+            + "/postnetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp.nc",
             **config["scenario"],
             **config["costs"],
             **config["export"]
@@ -265,7 +266,7 @@ rule add_export:
         ),
     output:
         RDIR
-        + "/prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export.nc",
+        + "/prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp.nc",
     script:
         "scripts/add_export.py"
 
@@ -602,28 +603,28 @@ if config["foresight"] == "overnight":
             # network=RDIR
             # + "/prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}.nc",
             network=RDIR
-            + "/prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export.nc",
+            + "/prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp.nc",
             costs=CDIR + "costs_{planning_horizons}.csv",
             configs=SDIR + "/configs/config.yaml",  # included to trigger copy_config rule
         output:
             RDIR
-            + "/postnetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export.nc",
+            + "/postnetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp.nc",
         shadow:
             "shallow"
         log:
             solver=RDIR
-            + "/logs/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_solver.log",
+            + "/logs/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp_solver.log",
             python=RDIR
-            + "/logs/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_python.log",
+            + "/logs/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp_python.log",
             memory=RDIR
-            + "/logs/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_memory.log",
+            + "/logs/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp_memory.log",
         threads: 25
         resources:
             mem_mb=config["solving"]["mem"],
         benchmark:
             (
                 RDIR
-                + "/benchmarks/solve_network/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export"
+                + "/benchmarks/solve_network/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp"
             )
         script:
             "scripts/solve_network.py"
@@ -643,7 +644,7 @@ rule make_summary:
         overrides="data/override_component_attrs",
         networks=expand(
             RDIR
-            + "/postnetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export.nc",
+            + "/postnetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp.nc",
             **config["scenario"],
             **config["costs"],
             **config["export"]
@@ -651,49 +652,49 @@ rule make_summary:
         costs=CDIR + "costs_{planning_horizons}.csv",
         plots=expand(
             RDIR
-            + "/maps/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}-costs-all_{planning_horizons}_{discountrate}_{demand}_{h2export}export.pdf",
+            + "/maps/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}-costs-all_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp.pdf",
             **config["scenario"],
             **config["costs"],
             **config["export"]
         ),
     output:
         nodal_costs=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/nodal_costs.csv",
+        + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/nodal_costs.csv",
         nodal_capacities=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/nodal_capacities.csv",
+        + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/nodal_capacities.csv",
         nodal_cfs=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/nodal_cfs.csv",
+        + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/nodal_cfs.csv",
         cfs=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/cfs.csv",
+        + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/cfs.csv",
         costs=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/costs.csv",
+        + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/costs.csv",
         capacities=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/capacities.csv",
+        + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/capacities.csv",
         curtailment=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/curtailment.csv",
+        + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/curtailment.csv",
         energy=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/energy.csv",
+        + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/energy.csv",
         supply=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/supply.csv",
+        + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/supply.csv",
         supply_energy=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/supply_energy.csv",
+        + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/supply_energy.csv",
         prices=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/prices.csv",
+        + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/prices.csv",
         weighted_prices=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/weighted_prices.csv",
+        + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/weighted_prices.csv",
         market_values=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/market_values.csv",
+        + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/market_values.csv",
         price_statistics=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/price_statistics.csv",
+        + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/price_statistics.csv",
         metrics=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/metrics.csv",
+        + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/metrics.csv",
     threads: 2
     resources:
         mem_mb=10000,
     benchmark:
         (
             SDIR
-            + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/benchmarks/make_summary"
+            + "/benchmarks/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/make_summary"
         )
     script:
         "scripts/make_summary.py"
@@ -703,17 +704,17 @@ rule plot_network:
     input:
         overrides="data/override_component_attrs",
         network=RDIR
-        + "/postnetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export.nc",
+        + "/postnetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp.nc",
     output:
         map=RDIR
-        + "/maps/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}-costs-all_{planning_horizons}_{discountrate}_{demand}_{h2export}export.pdf",
+        + "/maps/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}-costs-all_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp.pdf",
     threads: 2
     resources:
         mem_mb=10000,
     benchmark:
         (
             RDIR
-            + "/benchmarks/plot_network/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export"
+            + "/benchmarks/plot_network/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp"
         )
     script:
         "scripts/plot_network.py"
@@ -722,25 +723,25 @@ rule plot_network:
 rule plot_summary:
     input:
         costs=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/costs.csv",
+        + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/costs.csv",
         energy=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/energy.csv",
+        + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/energy.csv",
         balances=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/supply_energy.csv",
+        + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/supply_energy.csv",
     output:
         costs=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/graphs/costs.pdf",
+        + "/graphs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/costs.pdf",
         energy=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/graphs/energy.pdf",
+        + "/graphs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/energy.pdf",
         balances=SDIR
-        + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/graphs/balances-energy.pdf",
+        + "/graphs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/balances-energy.pdf",
     threads: 2
     resources:
         mem_mb=10000,
     benchmark:
         (
             SDIR
-            + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/benchmarks/plot_summary"
+            + "/benchmarks/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/plot_summary"
         )
     script:
         "scripts/plot_summary.py"
@@ -770,17 +771,17 @@ rule prepare_db:
         tech_colors=config["plotting"]["tech_colors"],
     input:
         network=RDIR
-        + "/postnetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export.nc",
+        + "/postnetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp.nc",
     output:
         db=RDIR
-        + "/summaries/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}-costs-all_{planning_horizons}_{discountrate}_{demand}_{h2export}export.csv",
+        + "/summaries/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}-costs-all_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp.csv",
     threads: 2
     resources:
         mem_mb=10000,
     benchmark:
         (
             RDIR
-            + "/benchmarks/prepare_db/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export"
+            + "/benchmarks/prepare_db/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp"
         )
     script:
         "scripts/prepare_db.py"
@@ -946,7 +947,7 @@ if config["foresight"] == "myopic":
             costs=config["costs"],
         input:
             network=RDIR
-            + "/prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export.nc",
+            + "/prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp.nc",
             powerplants=pypsaearth("resources/" + RDIR_PE + "powerplants.csv"),
             busmap_s=pypsaearth(
                 "resources/" + RDIR_PE + "bus_regions/busmap_elec_s{simpl}.csv"
@@ -964,7 +965,7 @@ if config["foresight"] == "myopic":
             existing_heating_distribution="resources/heating/existing_heating_distribution_{demand}_s{simpl}_{clusters}_{planning_horizons}.csv",
         output:
             RDIR
-            + "/prenetworks-brownfield/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export.nc",
+            + "/prenetworks-brownfield/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp.nc",
         wildcard_constraints:
             # TODO: The first planning_horizon needs to be aligned across scenarios
             # snakemake does not support passing functions to wildcard_constraints
@@ -975,10 +976,10 @@ if config["foresight"] == "myopic":
             mem_mb=2000,
         log:
             RDIR
-            + "/logs/add_existing_baseyear_elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export.log",
+            + "/logs/add_existing_baseyear_elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp.log",
         benchmark:
             RDIR
-            +"/benchmarks/add_existing_baseyear/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export"
+            +"/benchmarks/add_existing_baseyear/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp"
         script:
             "scripts/add_existing_baseyear.py"
 
@@ -1000,7 +1001,7 @@ if config["foresight"] == "myopic":
             RDIR
             + "/postnetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_"
             + planning_horizon_p
-            + "_{discountrate}_{demand}_{h2export}export.nc"
+            + "_{discountrate}_{demand}_{h2export}export_{h2mp}mp.nc"
         )
 
     rule add_brownfield:
@@ -1024,24 +1025,24 @@ if config["foresight"] == "myopic":
                 + "bus_regions/busmap_elec_s{simpl}_{clusters}.csv"
             ),
             network=RDIR
-            + "/prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export.nc",
+            + "/prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp.nc",
             network_p=solved_previous_horizon,  #solved network at previous time step
             costs=CDIR + "costs_{planning_horizons}.csv",
             cop_soil_total="resources/cops/cop_soil_total_elec_s{simpl}_{clusters}_{planning_horizons}.nc",
             cop_air_total="resources/cops/cop_air_total_elec_s{simpl}_{clusters}_{planning_horizons}.nc",
         output:
             RDIR
-            + "/prenetworks-brownfield/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export.nc",
+            + "/prenetworks-brownfield/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp.nc",
         threads: 4
         resources:
             mem_mb=10000,
         log:
             RDIR
-            + "/logs/add_brownfield_elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export.log",
+            + "/logs/add_brownfield_elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp.log",
         benchmark:
             (
                 RDIR
-                + "/benchmarks/add_brownfield/elec_s{simpl}_ec_{clusters}_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export"
+                + "/benchmarks/add_brownfield/elec_s{simpl}_ec_{clusters}_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp"
             )
         script:
             "./scripts/add_brownfield.py"
@@ -1059,30 +1060,30 @@ if config["foresight"] == "myopic":
         input:
             overrides="data/override_component_attrs",
             network=RDIR
-            + "/prenetworks-brownfield/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export.nc",
+            + "/prenetworks-brownfield/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp.nc",
             costs=CDIR + "costs_{planning_horizons}.csv",
             configs=SDIR + "/configs/config.yaml",  # included to trigger copy_config rule
         output:
             network=RDIR
-            + "/postnetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export.nc",
+            + "/postnetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp.nc",
             # config=RDIR
-            # + "/configs/config.elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export.yaml",
+            # + "/configs/config.elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp.yaml",
         shadow:
             "shallow"
         log:
             solver=RDIR
-            + "/logs/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_solver.log",
+            + "/logs/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp_solver.log",
             python=RDIR
-            + "/logs/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_python.log",
+            + "/logs/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp_python.log",
             memory=RDIR
-            + "/logs/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_memory.log",
+            + "/logs/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp_memory.log",
         threads: 25
         resources:
             mem_mb=config["solving"]["mem"],
         benchmark:
             (
                 RDIR
-                + "/benchmarks/solve_network/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export"
+                + "/benchmarks/solve_network/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp"
             )
         script:
             "./scripts/solve_network.py"
@@ -1091,7 +1092,7 @@ if config["foresight"] == "myopic":
         input:
             networks=expand(
                 RDIR
-                + "/postnetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export.nc",
+                + "/postnetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp.nc",
                 **config["scenario"],
                 **config["costs"],
                 **config["export"],
@@ -1102,126 +1103,126 @@ rule all:
     input:
         expand(
             SDIR
-            + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/nodal_costs.csv",
+            + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/nodal_costs.csv",
             **config["scenario"],
             **config["costs"],
             **config["export"]
         ),
         expand(
             SDIR
-            + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/nodal_capacities.csv",
+            + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/nodal_capacities.csv",
             **config["scenario"],
             **config["costs"],
             **config["export"]
         ),
         expand(
             SDIR
-            + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/nodal_cfs.csv",
+            + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/nodal_cfs.csv",
             **config["scenario"],
             **config["costs"],
             **config["export"]
         ),
         expand(
             SDIR
-            + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/cfs.csv",
+            + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/cfs.csv",
             **config["scenario"],
             **config["costs"],
             **config["export"]
         ),
         expand(
             SDIR
-            + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/costs.csv",
+            + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/costs.csv",
             **config["scenario"],
             **config["costs"],
             **config["export"]
         ),
         expand(
             SDIR
-            + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/capacities.csv",
+            + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/capacities.csv",
             **config["scenario"],
             **config["costs"],
             **config["export"]
         ),
         expand(
             SDIR
-            + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/curtailment.csv",
+            + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/curtailment.csv",
             **config["scenario"],
             **config["costs"],
             **config["export"]
         ),
         expand(
             SDIR
-            + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/energy.csv",
+            + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/energy.csv",
             **config["scenario"],
             **config["costs"],
             **config["export"]
         ),
         expand(
             SDIR
-            + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/supply.csv",
+            + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/supply.csv",
             **config["scenario"],
             **config["costs"],
             **config["export"]
         ),
         expand(
             SDIR
-            + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/supply_energy.csv",
+            + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/supply_energy.csv",
             **config["scenario"],
             **config["costs"],
             **config["export"]
         ),
         expand(
             SDIR
-            + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/prices.csv",
+            + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/prices.csv",
             **config["scenario"],
             **config["costs"],
             **config["export"]
         ),
         expand(
             SDIR
-            + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/weighted_prices.csv",
+            + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/weighted_prices.csv",
             **config["scenario"],
             **config["costs"],
             **config["export"]
         ),
         expand(
             SDIR
-            + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/market_values.csv",
+            + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/market_values.csv",
             **config["scenario"],
             **config["costs"],
             **config["export"]
         ),
         expand(
             SDIR
-            + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/price_statistics.csv",
+            + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/price_statistics.csv",
             **config["scenario"],
             **config["costs"],
             **config["export"]
         ),
         expand(
             SDIR
-            + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/csvs/metrics.csv",
+            + "/csvs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/metrics.csv",
             **config["scenario"],
             **config["costs"],
             **config["export"]
         ),
         expand(
             SDIR
-            + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/graphs/costs.pdf",
+            + "/graphs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/costs.pdf",
             **config["scenario"],
             **config["costs"],
             **config["export"]
         ),
         expand(
             SDIR
-            + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/graphs/energy.pdf",
+            + "/graphs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/energy.pdf",
             **config["scenario"],
             **config["costs"],
             **config["export"]
         ),
         expand(
             SDIR
-            + "/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export/graphs/balances-energy.pdf",
+            + "/graphs/{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export_{h2mp}mp/balances-energy.pdf",
             **config["scenario"],
             **config["costs"],
             **config["export"]

--- a/Snakefile
+++ b/Snakefile
@@ -250,6 +250,7 @@ rule add_export:
         snapshots=config["snapshots"],
         USD_to_EUR=config["costs"]["USD2013_to_EUR2013"],
         lifetime=config["costs"]["lifetime"],
+        constant_nodal_export=config["export"]["constant_nodal_export"],
     input:
         overrides="data/override_component_attrs",
         export_ports="data/export_ports.csv",
@@ -284,7 +285,7 @@ rule prepare_res_potentials:
         ),
     output:
         **{
-            f"{tech}_{year}_{discountrate}_potential_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_potential_s{simpl}_{clusters}.csv"
+            f"{tech}_{year}_{discountrate}_potential_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_potential_s{{simpl}}_{{clusters}}.csv"
             for tech in config["custom_data"]["renewables"]
             for year in config["scenario"]["planning_horizons"]
             for discountrate in config["costs"]["discountrate"]
@@ -292,7 +293,7 @@ rule prepare_res_potentials:
             for clusters in config["scenario"]["clusters"]
         },
         **{
-            f"{tech}_{year}_{discountrate}_installable_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_installable_s{simpl}_{clusters}.csv"
+            f"{tech}_{year}_{discountrate}_installable_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_installable_s{{simpl}}_{{clusters}}.csv"
             for tech in config["custom_data"]["renewables"]
             for year in config["scenario"]["planning_horizons"]
             for discountrate in config["costs"]["discountrate"]
@@ -310,7 +311,7 @@ rule override_respot:
         countries=config["countries"],
     input:
         **{
-            f"custom_res_pot_{tech}_{year}_{discountrate}_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_potential_s{simpl}_{clusters}.csv"
+            f"custom_res_pot_{tech}_{year}_{discountrate}_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_potential_s{{simpl}}_{{clusters}}.csv"
             for tech in config["custom_data"]["renewables"]
             for year in config["scenario"]["planning_horizons"]
             for discountrate in config["costs"]["discountrate"]
@@ -318,7 +319,7 @@ rule override_respot:
             for clusters in config["scenario"]["clusters"]
         },
         **{
-            f"custom_res_ins_{tech}_{year}_{discountrate}_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_installable_s{simpl}_{clusters}.csv"
+            f"custom_res_ins_{tech}_{year}_{discountrate}_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_installable_s{{simpl}}_{{clusters}}.csv"
             for tech in config["custom_data"]["renewables"]
             for year in config["scenario"]["planning_horizons"]
             for discountrate in config["costs"]["discountrate"]

--- a/Snakefile
+++ b/Snakefile
@@ -286,7 +286,7 @@ rule prepare_res_potentials:
         ),
     output:
         **{
-            f"{tech}_{year}_{discountrate}_potential_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_potential_s{{simpl}}_{{clusters}}.csv"
+            f"{tech}_{year}_{discountrate}_potential_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_potential_s{simpl}_{clusters}.csv"
             for tech in config["custom_data"]["renewables"]
             for year in config["scenario"]["planning_horizons"]
             for discountrate in config["costs"]["discountrate"]
@@ -294,7 +294,7 @@ rule prepare_res_potentials:
             for clusters in config["scenario"]["clusters"]
         },
         **{
-            f"{tech}_{year}_{discountrate}_installable_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_installable_s{{simpl}}_{{clusters}}.csv"
+            f"{tech}_{year}_{discountrate}_installable_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_installable_s{simpl}_{clusters}.csv"
             for tech in config["custom_data"]["renewables"]
             for year in config["scenario"]["planning_horizons"]
             for discountrate in config["costs"]["discountrate"]
@@ -312,7 +312,7 @@ rule override_respot:
         countries=config["countries"],
     input:
         **{
-            f"custom_res_pot_{tech}_{year}_{discountrate}_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_potential_s{{simpl}}_{{clusters}}.csv"
+            f"custom_res_pot_{tech}_{year}_{discountrate}_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_potential_s{simpl}_{clusters}.csv"
             for tech in config["custom_data"]["renewables"]
             for year in config["scenario"]["planning_horizons"]
             for discountrate in config["costs"]["discountrate"]
@@ -320,7 +320,7 @@ rule override_respot:
             for clusters in config["scenario"]["clusters"]
         },
         **{
-            f"custom_res_ins_{tech}_{year}_{discountrate}_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_installable_s{{simpl}}_{{clusters}}.csv"
+            f"custom_res_ins_{tech}_{year}_{discountrate}_s{simpl}_{clusters}": f"resources/custom_renewables/{tech}/{tech}_{year}_{discountrate}_installable_s{simpl}_{clusters}.csv"
             for tech in config["custom_data"]["renewables"]
             for year in config["scenario"]["planning_horizons"]
             for discountrate in config["costs"]["discountrate"]

--- a/config.bright_BI.yaml
+++ b/config.bright_BI.yaml
@@ -66,10 +66,10 @@ fossil_reserves:
 
 export:
   h2export: "endogenous" #,20,30,40,50,60,70,80,90,100] or "endogenous" in combination with h2mp # Yearly export demand in TWh
-  h2mp: [45,60,75] # Global hydrogen market price in EUR/MWh if h2export is set to endogenous
+  h2mp: [45, 60, 75] # Global hydrogen market price in EUR/MWh if h2export is set to endogenous
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
   export_profile: "constant" # use "ship" or "constant"
-  constant_nodal_export: True
+  constant_nodal_export: true
   ship:
     ship_capacity: 0.4 # TWh # 0.05 TWh for new ones, 0.003 TWh for Susio Frontier, 0.4 TWh according to Hampp2021: "Corresponds to 11360 t H2 (l) with LHV of 33.3333 Mwh/t_H2. Cihlar et al 2020 based on IEA 2019, Table 3-B"
     travel_time: 288 # hours # From Agadir to Rotterdam and back (12*24)

--- a/config.bright_BI.yaml
+++ b/config.bright_BI.yaml
@@ -6,7 +6,7 @@ summary_dir: results/
 costs_dir: data/ #TODO change to the equivalent of technology data
 
 run:
-  name: TScenariofsd
+  name: 241023_constant_delivery
   name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
   shared_cutouts: true  # set to true to share the default cutout(s) across runs
                         # Note: value false requires build_cutout to be enabled
@@ -28,7 +28,7 @@ scenario:
   opts:
   - "Co2L"
   sopts:
-  - "144H"
+  - "3H"
   demand:
   - "BI" # BI/DE/GH
 
@@ -40,7 +40,7 @@ policy_config:
     allowed_excess: 1.0
     is_reference: false # Whether or not this network is a reference case network, relevant only if additionality is _true_
     remove_h2_load: false #Whether or not to remove the h2 load from the network, relevant only if is_reference is _true_
-    path_to_ref: "/nimble/home/haz43975/pypsa-earth-sec/results/U_BI_AdaptedScenario/postnetworks/elec_s_11_ec_lv1.0_Co2L_720H_2035_0.071_BI_0export.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
+    path_to_ref: "/scratch/htc/cschauss/BRIGHT/submodules/pypsa-earth-sec/results/241023_constant_delivery/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.071_BI_0export.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
     limit_SMR_dispatch: true # Limits the dispatch of SMR to the reference case
     re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
 
@@ -69,6 +69,7 @@ export:
   store: false # [True, False] # specifies wether an export store to balance demand is implemented
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
   export_profile: "constant" # use "ship" or "constant"
+  constant_nodal_export: True
   ship:
     ship_capacity: 0.4 # TWh # 0.05 TWh for new ones, 0.003 TWh for Susio Frontier, 0.4 TWh according to Hampp2021: "Corresponds to 11360 t H2 (l) with LHV of 33.3333 Mwh/t_H2. Cihlar et al 2020 based on IEA 2019, Table 3-B"
     travel_time: 288 # hours # From Agadir to Rotterdam and back (12*24)

--- a/config.bright_BI.yaml
+++ b/config.bright_BI.yaml
@@ -6,7 +6,7 @@ summary_dir: results/
 costs_dir: data/ #TODO change to the equivalent of technology data
 
 run:
-  name: 241023_constant_delivery
+  name: 281023_endogenousexports
   name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
   shared_cutouts: true  # set to true to share the default cutout(s) across runs
                         # Note: value false requires build_cutout to be enabled
@@ -40,7 +40,7 @@ policy_config:
     allowed_excess: 1.0
     is_reference: false # Whether or not this network is a reference case network, relevant only if additionality is _true_
     remove_h2_load: false #Whether or not to remove the h2 load from the network, relevant only if is_reference is _true_
-    path_to_ref: "/scratch/htc/cschauss/BRIGHT/submodules/pypsa-earth-sec/results/241023_constant_delivery/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.071_BI_0export.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
+    path_to_ref: "/scratch/htc/cschauss/BRIGHT/submodules/pypsa-earth-sec/results/281023_endogenousexports/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.071_BI_0export.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
     limit_SMR_dispatch: true # Limits the dispatch of SMR to the reference case
     re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
 
@@ -65,8 +65,8 @@ fossil_reserves:
 
 
 export:
-  h2export: [10] #,20,30,40,50,60,70,80,90,100] # Yearly export demand in TWh
-  store: false # [True, False] # specifies wether an export store to balance demand is implemented
+  h2export: "endogenous" #,20,30,40,50,60,70,80,90,100] or "endogenous" in combination with h2mp # Yearly export demand in TWh
+  h2mp: [45,60,75] # Global hydrogen market price in EUR/MWh if h2export is set to endogenous
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
   export_profile: "constant" # use "ship" or "constant"
   constant_nodal_export: True
@@ -649,3 +649,4 @@ plotting:
     oil pipeline: "grey"
     agriculture biomass: "green"
     biomass to liquid: "green"
+    H2 pipeline: m

--- a/config.bright_BI.yaml
+++ b/config.bright_BI.yaml
@@ -40,7 +40,7 @@ policy_config:
     allowed_excess: 1.0
     is_reference: false # Whether or not this network is a reference case network, relevant only if additionality is _true_
     remove_h2_load: false #Whether or not to remove the h2 load from the network, relevant only if is_reference is _true_
-    path_to_ref: "/scratch/htc/cschauss/BRIGHT/submodules/pypsa-earth-sec/results/281023_endogenousexports/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.071_BI_0export.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
+    path_to_ref: "/scratch/htc/cschauss/BRIGHT/submodules/pypsa-earth-sec/results/281023_endogenousexports/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.071_BI_0export_endogenousmp.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
     limit_SMR_dispatch: true # Limits the dispatch of SMR to the reference case
     re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
 

--- a/config.bright_BI_ref.yaml
+++ b/config.bright_BI_ref.yaml
@@ -6,7 +6,7 @@ summary_dir: results/
 costs_dir: data/ #TODO change to the equivalent of technology data
 
 run:
-  name: 241023_constant_delivery
+  name: 281023_endogenousexports
   name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
   shared_cutouts: true  # set to true to share the default cutout(s) across runs
                         # Note: value false requires build_cutout to be enabled
@@ -66,7 +66,7 @@ fossil_reserves:
 
 
 export:
-  h2export: [0] #[0,10,20,30,40,50,60,70,80,90,100] # Yearly export demand in TWh
+
   store: false # [True, False] # specifies wether an export store to balance demand is implemented
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
   export_profile: "constant" # use "ship" or "constant"
@@ -94,7 +94,7 @@ custom_data:
 
 costs: # Costs used in PyPSA-Earth-Sec. Year depends on the wildcard planning_horizon in the scenario section
   version: v0.6.2
-  lifetime: 25 #default lifetime
+  lifetime: 25 #default lifetimeH2 pipeline: m
   # From a Lion Hirth paper, also reflects average of Noothout et al 2016
   discountrate: [0.071] #, 0.086, 0.111]
   # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html # noqa: E501
@@ -651,3 +651,4 @@ plotting:
     high-temp electrolysis: "magenta"
     oil pipeline: "grey"
     agriculture biomass: "green"
+    H2 pipeline: m

--- a/config.bright_BI_ref.yaml
+++ b/config.bright_BI_ref.yaml
@@ -6,7 +6,7 @@ summary_dir: results/
 costs_dir: data/ #TODO change to the equivalent of technology data
 
 run:
-  name: 20241021_biofuels
+  name: 241023_constant_delivery
   name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
   shared_cutouts: true  # set to true to share the default cutout(s) across runs
                         # Note: value false requires build_cutout to be enabled
@@ -28,7 +28,7 @@ scenario:
   opts:
   - "Co2L"
   sopts:
-  - "8H"
+  - "3H"
   demand:
   - "BI" # BI/DE/GH
 

--- a/config.bright_BI_ref.yaml
+++ b/config.bright_BI_ref.yaml
@@ -66,10 +66,12 @@ fossil_reserves:
 
 
 export:
-
+  h2export: [0] #,20,30,40,50,60,70,80,90,100] or "endogenous" in combination with h2mp # Yearly export demand in TWh
+  h2mp: "endogenous" # Global hydrogen market price in EUR/MWh if h2export is set to endogenous else "endogenous"
   store: false # [True, False] # specifies wether an export store to balance demand is implemented
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
   export_profile: "constant" # use "ship" or "constant"
+  constant_nodal_export: true
   ship:
     ship_capacity: 0.4 # TWh # 0.05 TWh for new ones, 0.003 TWh for Susio Frontier, 0.4 TWh according to Hampp2021: "Corresponds to 11360 t H2 (l) with LHV of 33.3333 Mwh/t_H2. Cihlar et al 2020 based on IEA 2019, Table 3-B"
     travel_time: 288 # hours # From Agadir to Rotterdam and back (12*24)
@@ -94,7 +96,7 @@ custom_data:
 
 costs: # Costs used in PyPSA-Earth-Sec. Year depends on the wildcard planning_horizon in the scenario section
   version: v0.6.2
-  lifetime: 25 #default lifetimeH2 pipeline: m
+  lifetime: 25 #default lifetime
   # From a Lion Hirth paper, also reflects average of Noothout et al 2016
   discountrate: [0.071] #, 0.086, 0.111]
   # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html # noqa: E501

--- a/config.bright_DE.yaml
+++ b/config.bright_DE.yaml
@@ -66,11 +66,11 @@ fossil_reserves:
 
 export:
   h2export: "endogenous" #,20,30,40,50,60,70,80,90,100] or "endogenous" in combination with h2mp # Yearly export demand in TWh
-  h2mp: [45,60,75] # Global hydrogen market price in EUR/MWh if h2export is set to endogenous
+  h2mp: [45, 60, 75] # Global hydrogen market price in EUR/MWh if h2export is set to endogenous
   store: false # [True, False] # specifies wether an export store to balance demand is implemented
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
   export_profile: "constant" # use "ship" or "constant"
-  constant_nodal_export: True
+  constant_nodal_export: true
   ship:
     ship_capacity: 0.4 # TWh # 0.05 TWh for new ones, 0.003 TWh for Susio Frontier, 0.4 TWh according to Hampp2021: "Corresponds to 11360 t H2 (l) with LHV of 33.3333 Mwh/t_H2. Cihlar et al 2020 based on IEA 2019, Table 3-B"
     travel_time: 288 # hours # From Agadir to Rotterdam and back (12*24)

--- a/config.bright_DE.yaml
+++ b/config.bright_DE.yaml
@@ -40,7 +40,7 @@ policy_config:
     allowed_excess: 1.0
     is_reference: false # Whether or not this network is a reference case network, relevant only if additionality is _true_
     remove_h2_load: false #Whether or not to remove the h2 load from the network, relevant only if is_reference is _true_
-    path_to_ref: "/scratch/htc/cschauss/BRIGHT/submodules/pypsa-earth-sec/results/281023_endogenousexports/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.071_DE_0export.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
+    path_to_ref: "/scratch/htc/cschauss/BRIGHT/submodules/pypsa-earth-sec/results/281023_endogenousexports/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.071_DE_0export_endogenousmp.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
     limit_SMR_dispatch: true # Limits the dispatch of SMR to the reference case
     re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
 

--- a/config.bright_DE.yaml
+++ b/config.bright_DE.yaml
@@ -6,7 +6,7 @@ summary_dir: results/
 costs_dir: data/ #TODO change to the equivalent of technology data
 
 run:
-  name: 092524_test_2
+  name: 241023_constant_delivery
   name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
   shared_cutouts: true  # set to true to share the default cutout(s) across runs
                         # Note: value false requires build_cutout to be enabled
@@ -28,7 +28,7 @@ scenario:
   opts:
   - "Co2L"
   sopts:
-  - "720H"
+  - "3H"
   demand:
   - "DE" # BI/DE/GH
 
@@ -40,7 +40,7 @@ policy_config:
     allowed_excess: 1.0
     is_reference: false # Whether or not this network is a reference case network, relevant only if additionality is _true_
     remove_h2_load: false #Whether or not to remove the h2 load from the network, relevant only if is_reference is _true_
-    path_to_ref: "/nimble/home/haz43975/pypsa-earth-sec/results/092524_test_2/postnetworks/elec_s_11_ec_lv1.0_Co2L_720H_2035_0.071_DE_0export.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
+    path_to_ref: "/scratch/htc/cschauss/BRIGHT/submodules/pypsa-earth-sec/results/241023_constant_delivery/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.071_DE_0export.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
     limit_SMR_dispatch: true # Limits the dispatch of SMR to the reference case
     re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
 
@@ -69,6 +69,7 @@ export:
   store: false # [True, False] # specifies wether an export store to balance demand is implemented
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
   export_profile: "constant" # use "ship" or "constant"
+  constant_nodal_export: True
   ship:
     ship_capacity: 0.4 # TWh # 0.05 TWh for new ones, 0.003 TWh for Susio Frontier, 0.4 TWh according to Hampp2021: "Corresponds to 11360 t H2 (l) with LHV of 33.3333 Mwh/t_H2. Cihlar et al 2020 based on IEA 2019, Table 3-B"
     travel_time: 288 # hours # From Agadir to Rotterdam and back (12*24)

--- a/config.bright_DE.yaml
+++ b/config.bright_DE.yaml
@@ -6,7 +6,7 @@ summary_dir: results/
 costs_dir: data/ #TODO change to the equivalent of technology data
 
 run:
-  name: 241023_constant_delivery
+  name: 281023_endogenousexports
   name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
   shared_cutouts: true  # set to true to share the default cutout(s) across runs
                         # Note: value false requires build_cutout to be enabled
@@ -40,7 +40,7 @@ policy_config:
     allowed_excess: 1.0
     is_reference: false # Whether or not this network is a reference case network, relevant only if additionality is _true_
     remove_h2_load: false #Whether or not to remove the h2 load from the network, relevant only if is_reference is _true_
-    path_to_ref: "/scratch/htc/cschauss/BRIGHT/submodules/pypsa-earth-sec/results/241023_constant_delivery/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.071_DE_0export.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
+    path_to_ref: "/scratch/htc/cschauss/BRIGHT/submodules/pypsa-earth-sec/results/281023_endogenousexports/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.071_DE_0export.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
     limit_SMR_dispatch: true # Limits the dispatch of SMR to the reference case
     re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
 
@@ -65,7 +65,8 @@ fossil_reserves:
 
 
 export:
-  h2export: [200] #[10,20,30,40,50,60,70,80,90,100] # Yearly export demand in TWh
+  h2export: "endogenous" #,20,30,40,50,60,70,80,90,100] or "endogenous" in combination with h2mp # Yearly export demand in TWh
+  h2mp: [45,60,75] # Global hydrogen market price in EUR/MWh if h2export is set to endogenous
   store: false # [True, False] # specifies wether an export store to balance demand is implemented
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
   export_profile: "constant" # use "ship" or "constant"
@@ -649,3 +650,4 @@ plotting:
     oil pipeline: "grey"
     agriculture biomass: "green"
     biomass to liquid: "green"
+    H2 pipeline: m

--- a/config.bright_DE_ref.yaml
+++ b/config.bright_DE_ref.yaml
@@ -6,7 +6,7 @@ summary_dir: results/
 costs_dir: data/ #TODO change to the equivalent of technology data
 
 run:
-  name: 092524_test_2
+  name: 241023_constant_delivery
   name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
   shared_cutouts: true  # set to true to share the default cutout(s) across runs
                         # Note: value false requires build_cutout to be enabled
@@ -28,7 +28,7 @@ scenario:
   opts:
   - "Co2L"
   sopts:
-  - "720H"
+  - "3H"
   demand:
   - "DE" # BI/DE/GH
 

--- a/config.bright_DE_ref.yaml
+++ b/config.bright_DE_ref.yaml
@@ -70,6 +70,7 @@ export:
   store: false # [True, False] # specifies wether an export store to balance demand is implemented
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
   export_profile: "constant" # use "ship" or "constant"
+  constant_nodal_export: true
   ship:
     ship_capacity: 0.4 # TWh # 0.05 TWh for new ones, 0.003 TWh for Susio Frontier, 0.4 TWh according to Hampp2021: "Corresponds to 11360 t H2 (l) with LHV of 33.3333 Mwh/t_H2. Cihlar et al 2020 based on IEA 2019, Table 3-B"
     travel_time: 288 # hours # From Agadir to Rotterdam and back (12*24)

--- a/config.bright_DE_ref.yaml
+++ b/config.bright_DE_ref.yaml
@@ -6,7 +6,7 @@ summary_dir: results/
 costs_dir: data/ #TODO change to the equivalent of technology data
 
 run:
-  name: 241023_constant_delivery
+  name: 281023_endogenousexports
   name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
   shared_cutouts: true  # set to true to share the default cutout(s) across runs
                         # Note: value false requires build_cutout to be enabled
@@ -65,7 +65,8 @@ fossil_reserves:
 
 
 export:
-  h2export: [0] #[10,20,30,40,50,60,70,80,90,100] # Yearly export demand in TWh
+  h2export: [0] #,20,30,40,50,60,70,80,90,100] or "endogenous" in combination with h2mp # Yearly export demand in TWh
+  h2mp: "endogenous" # Global hydrogen market price in EUR/MWh if h2export is set to endogenous else "endogenous"
   store: false # [True, False] # specifies wether an export store to balance demand is implemented
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
   export_profile: "constant" # use "ship" or "constant"
@@ -654,3 +655,4 @@ plotting:
     oil pipeline: "grey"
     agriculture biomass: "green"
     biomass to liquid: "green"
+    H2 pipeline: m

--- a/config.bright_GH.yaml
+++ b/config.bright_GH.yaml
@@ -66,11 +66,11 @@ fossil_reserves:
 
 export:
   h2export: "endogenous" #,20,30,40,50,60,70,80,90,100] or "endogenous" in combination with h2mp # Yearly export demand in TWh
-  h2mp: [45,60,75] # Global hydrogen market price in EUR/MWh if h2export is set to endogenous
+  h2mp: [45, 60, 75] # Global hydrogen market price in EUR/MWh if h2export is set to endogenous
   store: false # [True, False] # specifies wether an export store to balance demand is implemented
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
   export_profile: "constant" # use "ship" or "constant"
-  constant_nodal_export: True
+  constant_nodal_export: true
   ship:
     ship_capacity: 0.4 # TWh # 0.05 TWh for new ones, 0.003 TWh for Susio Frontier, 0.4 TWh according to Hampp2021: "Corresponds to 11360 t H2 (l) with LHV of 33.3333 Mwh/t_H2. Cihlar et al 2020 based on IEA 2019, Table 3-B"
     travel_time: 288 # hours # From Agadir to Rotterdam and back (12*24)

--- a/config.bright_GH.yaml
+++ b/config.bright_GH.yaml
@@ -40,7 +40,7 @@ policy_config:
     allowed_excess: 1.0
     is_reference: false # Whether or not this network is a reference case network, relevant only if additionality is _true_
     remove_h2_load: false #Whether or not to remove the h2 load from the network, relevant only if is_reference is _true_
-    path_to_ref: "/scratch/htc/cschauss/BRIGHT/submodules/pypsa-earth-sec/results/281023_endogenousexports/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.071_GH_0export.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
+    path_to_ref: "/scratch/htc/cschauss/BRIGHT/submodules/pypsa-earth-sec/results/281023_endogenousexports/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.071_GH_0export_endogenousmp.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
     limit_SMR_dispatch: true # Limits the dispatch of SMR to the reference case
     re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
 

--- a/config.bright_GH.yaml
+++ b/config.bright_GH.yaml
@@ -6,7 +6,7 @@ summary_dir: results/
 costs_dir: data/ #TODO change to the equivalent of technology data
 
 run:
-  name: U_GH_AdaptedScenario_2
+  name: 241023_constant_delivery
   name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
   shared_cutouts: true  # set to true to share the default cutout(s) across runs
                         # Note: value false requires build_cutout to be enabled
@@ -28,7 +28,7 @@ scenario:
   opts:
   - "Co2L"
   sopts:
-  - "720H"
+  - "3H"
   demand:
   - "GH" # BI/DE/GH
 
@@ -40,7 +40,7 @@ policy_config:
     allowed_excess: 1.0
     is_reference: false # Whether or not this network is a reference case network, relevant only if additionality is _true_
     remove_h2_load: false #Whether or not to remove the h2 load from the network, relevant only if is_reference is _true_
-    path_to_ref: "/nimble/home/haz43975/pypsa-earth-sec/results/U_GH_AdaptedScenario_2/postnetworks/elec_s_11_ec_lv1.0_Co2L_720H_2035_0.071_GH_0export.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
+    path_to_ref: "/scratch/htc/cschauss/BRIGHT/submodules/pypsa-earth-sec/results/241023_constant_delivery/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.071_GH_0export.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
     limit_SMR_dispatch: true # Limits the dispatch of SMR to the reference case
     re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
 
@@ -69,6 +69,7 @@ export:
   store: false # [True, False] # specifies wether an export store to balance demand is implemented
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
   export_profile: "constant" # use "ship" or "constant"
+  constant_nodal_export: True
   ship:
     ship_capacity: 0.4 # TWh # 0.05 TWh for new ones, 0.003 TWh for Susio Frontier, 0.4 TWh according to Hampp2021: "Corresponds to 11360 t H2 (l) with LHV of 33.3333 Mwh/t_H2. Cihlar et al 2020 based on IEA 2019, Table 3-B"
     travel_time: 288 # hours # From Agadir to Rotterdam and back (12*24)

--- a/config.bright_GH.yaml
+++ b/config.bright_GH.yaml
@@ -6,7 +6,7 @@ summary_dir: results/
 costs_dir: data/ #TODO change to the equivalent of technology data
 
 run:
-  name: 241023_constant_delivery
+  name: 281023_endogenousexports
   name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
   shared_cutouts: true  # set to true to share the default cutout(s) across runs
                         # Note: value false requires build_cutout to be enabled
@@ -40,7 +40,7 @@ policy_config:
     allowed_excess: 1.0
     is_reference: false # Whether or not this network is a reference case network, relevant only if additionality is _true_
     remove_h2_load: false #Whether or not to remove the h2 load from the network, relevant only if is_reference is _true_
-    path_to_ref: "/scratch/htc/cschauss/BRIGHT/submodules/pypsa-earth-sec/results/241023_constant_delivery/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.071_GH_0export.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
+    path_to_ref: "/scratch/htc/cschauss/BRIGHT/submodules/pypsa-earth-sec/results/281023_endogenousexports/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.071_GH_0export.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
     limit_SMR_dispatch: true # Limits the dispatch of SMR to the reference case
     re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
 
@@ -65,7 +65,8 @@ fossil_reserves:
 
 
 export:
-  h2export: [10] #,20,30,40,50,60,70,80,90,100] # Yearly export demand in TWh
+  h2export: "endogenous" #,20,30,40,50,60,70,80,90,100] or "endogenous" in combination with h2mp # Yearly export demand in TWh
+  h2mp: [45,60,75] # Global hydrogen market price in EUR/MWh if h2export is set to endogenous
   store: false # [True, False] # specifies wether an export store to balance demand is implemented
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
   export_profile: "constant" # use "ship" or "constant"
@@ -649,3 +650,4 @@ plotting:
     oil pipeline: "grey"
     agriculture biomass: "green"
     biomass to liquid: "green"
+    H2 pipeline: m

--- a/config.bright_GH_ref.yaml
+++ b/config.bright_GH_ref.yaml
@@ -6,7 +6,7 @@ summary_dir: results/
 costs_dir: data/ #TODO change to the equivalent of technology data
 
 run:
-  name: U_GH_AdaptedScenario_2
+  name: 241023_constant_delivery
   name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
   shared_cutouts: true  # set to true to share the default cutout(s) across runs
                         # Note: value false requires build_cutout to be enabled
@@ -28,7 +28,7 @@ scenario:
   opts:
   - "Co2L"
   sopts:
-  - "720H"
+  - "3H"
   demand:
   - "GH" # BI/DE/GH
 

--- a/config.bright_GH_ref.yaml
+++ b/config.bright_GH_ref.yaml
@@ -6,7 +6,7 @@ summary_dir: results/
 costs_dir: data/ #TODO change to the equivalent of technology data
 
 run:
-  name: 241023_constant_delivery
+  name: 281023_endogenousexports
   name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
   shared_cutouts: true  # set to true to share the default cutout(s) across runs
                         # Note: value false requires build_cutout to be enabled
@@ -65,8 +65,8 @@ fossil_reserves:
 
 
 export:
-  h2export: [0] #[0,10,20,30,40,50,60,70,80,90,100] # Yearly export demand in TWh
-  store: false # [True, False] # specifies wether an export store to balance demand is implemented
+  h2export: [0] #,20,30,40,50,60,70,80,90,100] or "endogenous" in combination with h2mp # Yearly export demand in TWh
+  h2mp: "endogenous" # Global hydrogen market price in EUR/MWh if h2export is set to endogenous else "endogenous"
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
   export_profile: "constant" # use "ship" or "constant"
   ship:
@@ -648,3 +648,4 @@ plotting:
     oil pipeline: "grey"
     agriculture biomass: "green"
     biomass to liquid: "green"
+    H2 pipeline: m

--- a/config.bright_GH_ref.yaml
+++ b/config.bright_GH_ref.yaml
@@ -69,6 +69,7 @@ export:
   h2mp: "endogenous" # Global hydrogen market price in EUR/MWh if h2export is set to endogenous else "endogenous"
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
   export_profile: "constant" # use "ship" or "constant"
+  constant_nodal_export: true
   ship:
     ship_capacity: 0.4 # TWh # 0.05 TWh for new ones, 0.003 TWh for Susio Frontier, 0.4 TWh according to Hampp2021: "Corresponds to 11360 t H2 (l) with LHV of 33.3333 Mwh/t_H2. Cihlar et al 2020 based on IEA 2019, Table 3-B"
     travel_time: 288 # hours # From Agadir to Rotterdam and back (12*24)

--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -90,6 +90,8 @@ def add_export(n, hydrogen_buses_ports, export_profile):
         bus1="H2 export bus",
         p_nom_extendable=True,
     )
+    if snakemake.params.constant_nodal_export:
+        n.links.loc[n.links.index.str.contains("export"), "p_min_pu"] = 1
 
     export_links = n.links[n.links.index.str.contains("export")]
     logger.info(export_links)

--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -125,20 +125,40 @@ def add_export(n, hydrogen_buses_ports, export_profile):
     elif snakemake.params.store == False:
         pass
 
-    # add load
-    n.add(
-        "Load",
-        "H2 export load",
-        bus="H2 export bus",
-        carrier="H2",
-        p_set=export_profile,
-    )
+    if (
+        snakemake.wildcards.h2mp != "endogenous"
+        and snakemake.wildcards.h2export == "endogenous"
+    ):
+        # add negative generator to export bus with global H2 market price as remuneration
+        n.add(
+            "Generator",
+            "H2 export",
+            bus="H2 export bus",
+            carrier="H2",
+            p_nom_extendable=True,
+            capital_cost=0,
+            marginal_cost=snakemake.wildcards["h2mp"],
+            p_min_pu=-1,
+            p_max_pu=0,
+        )
+    else:
+        # add load
+        n.add(
+            "Load",
+            "H2 export load",
+            bus="H2 export bus",
+            carrier="H2",
+            p_set=export_profile,
+        )
 
     return
 
 
 def create_export_profile():
     """This function creates the export profile based on the annual export demand and resamples it to temp resolution obtained from the wildcard"""
+
+    if snakemake.wildcards.h2export == "endogenous":
+        return None
 
     export_h2 = eval(snakemake.wildcards["h2export"]) * 1e6  # convert TWh to MWh
 

--- a/scripts/build_ship_profile.py
+++ b/scripts/build_ship_profile.py
@@ -73,10 +73,13 @@ if __name__ == "__main__":
 
     # Get parameters from config and wildcard
     ship_opts = snakemake.params.ship_opts
-    export_volume = eval(snakemake.wildcards.h2export)
+    if snakemake.wildcards.h2export != "endogenous":
+        export_volume = eval(snakemake.wildcards.h2export)
+    else:
+        export_volume = "endogenous"
 
     # Create export profile
-    if export_volume > 0:
+    if export_volume != "endogenous" and export_volume > 0:
         export_profile = build_ship_profile(export_volume, ship_opts)
     else:
         export_profile = pd.Series(

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -642,6 +642,7 @@ def make_summaries(networks_dict):
             "discount_rate",
             "demand",
             "export",
+            "h2mp",
         ],
     )
 
@@ -707,9 +708,10 @@ if __name__ == "__main__":
             snakemake.wildcards["discountrate"],
             snakemake.wildcards["demand"],
             snakemake.wildcards["h2export"],
+            snakemake.wildcards["h2mp"],
         ): snakemake.params.results_dir
         + snakemake.params.run["name"]
-        + f"/postnetworks/elec_s{snakemake.wildcards['simpl']}_{snakemake.wildcards['clusters']}_ec_l{snakemake.wildcards['ll']}_{snakemake.wildcards['opts']}_{snakemake.wildcards['sopts']}_{snakemake.wildcards['planning_horizons']}_{snakemake.wildcards['discountrate']}_{snakemake.wildcards['demand']}_{snakemake.wildcards['h2export']}export.nc"
+        + f"/postnetworks/elec_s{snakemake.wildcards['simpl']}_{snakemake.wildcards['clusters']}_ec_l{snakemake.wildcards['ll']}_{snakemake.wildcards['opts']}_{snakemake.wildcards['sopts']}_{snakemake.wildcards['planning_horizons']}_{snakemake.wildcards['discountrate']}_{snakemake.wildcards['demand']}_{snakemake.wildcards['h2export']}export_{snakemake.wildcards['h2mp']}mp.nc"
     }
 
     print(networks_dict)

--- a/submit.sh
+++ b/submit.sh
@@ -2,10 +2,19 @@
 
 micromamba activate pypsa-earth
 
+cp config.bright_BI_ref.yaml config.yaml
+snakemake --profile slurm all
+
 cp config.bright_BI.yaml config.yaml
 snakemake --profile slurm all
 
+cp config.bright_DE_ref.yaml config.yaml
+snakemake --profile slurm all
+
 cp config.bright_DE.yaml config.yaml
+snakemake --profile slurm all
+
+cp config.bright_GH_ref.yaml config.yaml
 snakemake --profile slurm all
 
 cp config.bright_GH.yaml config.yaml


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR endogenizes the decision on the optimal hydrogen export quantity. This decision is influenced by the exogenously set global hydrogen market price, introduced as a wildcard in the model, and adjustable via the parameter export:h2mp as an integer or float. The implicit unit for this parameter is €/MWh. Endogenization is achieved by attaching a negative hydrogen export generator component, which is remunerated based on the exogenous global market price. This component thereby reduces the objective value through its operation.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
