### PR TITLE
allow different interest rates for capex calculation of custom res

### DIFF
--- a/config.bright.yaml
+++ b/config.bright.yaml
@@ -29,8 +29,7 @@ scenario:
   - "Co2L"
   sopts:
   - "3H"
-  demand:
-  - ["BI", "DE", "GH"] # BI/DE/GH
+  demand: ["BI", "DE", "GH"] # BI/DE/GH
 
 policy_config:
   hydrogen:
@@ -66,7 +65,7 @@ fossil_reserves:
 
 export:
   h2export: "endogenous" #,20,30,40,50,60,70,80,90,100] or "endogenous" in combination with h2mp # Yearly export demand in TWh
-  h2mp: [70,90,100,110,120] # Global hydrogen market price in EUR/MWh if h2export is set to endogenous
+  h2mp: [70, 72.5, 75, 77.5, 80, 82.5, 85, 87.5, 90] # Global hydrogen market price in EUR/MWh if h2export is set to endogenous
   store: false # [True, False] # specifies wether an export store to balance demand is implemented
   store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
   export_profile: "constant" # use "ship" or "constant"
@@ -94,7 +93,7 @@ custom_data:
   rename_industry_carriers: {"Electricity": "electricity", "Biofuels": "solid biomass", "Heat": "low-temperature heat", "Natural Gas": "gas", "Coal": "coal", "Hydrogen": "hydrogen", "Oil": "oil"}
 
 costs: # Costs used in PyPSA-Earth-Sec. Year depends on the wildcard planning_horizon in the scenario section
-  version: v0.6.2
+  version: v0.9.2
   lifetime: 25 #default lifetime
   # From a Lion Hirth paper, also reflects average of Noothout et al 2016
   discountrate: [0.071] #, 0.086, 0.111]
@@ -112,7 +111,7 @@ costs: # Costs used in PyPSA-Earth-Sec. Year depends on the wildcard planning_ho
     H2: 0.
     battery: 0.
 
-  electrolyzer_cc: [0.7,1.0,1.3]
+  electrolyzer_cc: [0.5]
 
   emission_prices: # only used with the option Ep (emission prices)
     co2: 0.

--- a/config.pypsa-earth.yaml
+++ b/config.pypsa-earth.yaml
@@ -338,7 +338,7 @@ renewable:
 # Costs Configuration (Do not remove, needed for Sphynx documentation).
 costs:
   year: 2030
-  version: v0.5.0
+  version: v0.9.2
   rooftop_share: 0.14  # based on the potentials, assuming  (0.1 kW/m2 and 10 m2/person)
   USD2013_to_EUR2013: 0.7532 # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html
   fill_values:
@@ -349,7 +349,7 @@ costs:
     investment: 0
     lifetime: 25
     CO2 intensity: 0
-    discount rate: 0.071
+    discount rate: [0.071]
   marginal_cost: # EUR/MWh
     solar: 0.01
     onwind: 0.015

--- a/scripts/prepare_res_potentials.py
+++ b/scripts/prepare_res_potentials.py
@@ -212,6 +212,7 @@ def prepare_enertile(df, df_t):
         {
             "p_nom_max": "sum",
             "annualcostEuroPMW": "mean",
+            "investmentEuroPKW": "mean",
             "fixedomEuroPKW": "mean",
             "installedcapacity": "sum",
             "lifetime": "mean",


### PR DESCRIPTION
## Changes proposed in this Pull Request
To allow the usage of different interest rates in combination with the custom RES data of Enertile it is required to re-calculate the CAPEX in the script `override_respot`.

Furthermore the technology data version is updated to a recent one.
