### PR TITLE
setup for interest rate sensitivity; fix bugs

### DIFF
--- a/config.bright_high.yaml
+++ b/config.bright_high.yaml
@@ -1,0 +1,656 @@
+logging_level: INFO
+tutorial: false
+
+results_dir: results/
+summary_dir: results/
+costs_dir: data/ #TODO change to the equivalent of technology data
+
+run:
+  name: 241107_ir_sensitivity
+  name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
+  shared_cutouts: true  # set to true to share the default cutout(s) across runs
+                        # Note: value false requires build_cutout to be enabled
+
+foresight: overnight
+
+# option to disable the subworkflow to ease the analyses
+disable_subworkflow: false
+
+scenario:
+  simpl: # only relevant for PyPSA-Eur
+  - ""
+  clusters: # number of nodes in Europe, any integer between 37 (1 node per country-zone) and several hundred
+  - 11
+  planning_horizons: # investment years for myopic and perfect; or costs year for overnight
+  - 2035
+  ll:
+  - "v1.0"
+  opts:
+  - "Co2L"
+  sopts:
+  - "3H"
+  demand: ["BI", "DE", "GH"] # BI/DE/GH
+
+policy_config:
+  hydrogen:
+    temporal_matching: "hour" #either "hour", "month", "year", "no_res_matching"
+    spatial_matching: false
+    additionality: true # RE electricity is equal to the amount required for additional hydrogen export compared to the 0 export case ("reference_case")
+    allowed_excess: 1.0
+    is_reference: false # Whether or not this network is a reference case network, relevant only if additionality is _true_
+    remove_h2_load: false #Whether or not to remove the h2 load from the network, relevant only if is_reference is _true_
+    path_to_ref: "/scratch/htc/cschauss/BRIGHT/submodules/pypsa-earth-sec/results/241107_ir_sensitivity/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.1_scenario_0export_endogenousmp.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
+    limit_SMR_dispatch: true # Limits the dispatch of SMR to the reference case
+    re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
+  renewables:
+      ratio_rooftop_to_utility_solar:  # insert value to activate, leave empty to disable
+      
+clustering_options:
+  alternative_clustering: true
+
+countries: ['BR']
+
+demand_data:
+  update_data: true # if true, the workflow downloads the energy balances data saved in data/demand/unsd/data again. Turn on for the first run.
+  base_year: 2019
+
+  other_industries: false # Whether or not to include industries that are not specified. some countries have has exageratted numbers, check carefully.
+  aluminium_year: 2019 # Year of the aluminium demand data specified in `data/AL_production.csv`
+
+
+enable:
+  retrieve_cost_data: true # if true, the workflow overwrites the cost data saved in data/costs again
+
+fossil_reserves:
+  oil: 2000 #TWh Maybe reduntant
+
+
+export:
+  h2export: "endogenous" #,20,30,40,50,60,70,80,90,100] or "endogenous" in combination with h2mp # Yearly export demand in TWh
+  h2mp: [70, 72.5, 75, 77.5, 80, 82.5, 85, 87.5, 90] # Global hydrogen market price in EUR/MWh if h2export is set to endogenous
+  store: false # [True, False] # specifies wether an export store to balance demand is implemented
+  store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
+  export_profile: "constant" # use "ship" or "constant"
+  constant_nodal_export: true
+  ship:
+    ship_capacity: 0.4 # TWh # 0.05 TWh for new ones, 0.003 TWh for Susio Frontier, 0.4 TWh according to Hampp2021: "Corresponds to 11360 t H2 (l) with LHV of 33.3333 Mwh/t_H2. Cihlar et al 2020 based on IEA 2019, Table 3-B"
+    travel_time: 288 # hours # From Agadir to Rotterdam and back (12*24)
+    fill_time: 24 # hours, for 48h see Hampp2021
+    unload_time: 24 # hours for 48h see Hampp2021
+
+custom_data:
+  renewables_enertile: ["onwind", "onwind_rest", "solar", "solar-rooftop"]
+  renewables: ["onwind", "onwind2", "onwind3", "onwind4", "solar", "solar-rooftop"] # ['csp', 'rooftop-solar', 'solar']
+  energy_totals: true
+  elec_demand: true
+  heat_demand: false
+  industry_demand: true
+  industry_database: true
+  transport_demand: false
+  water_costs: false
+  h2_underground: false
+  add_existing: false
+  custom_sectors: false
+  gas_network: false # If "True" then a custom .csv file must be placed in "resources/custom_data/pipelines.csv" , If "False" the user can choose btw "greenfield" or Model built-in datasets. Please refer to ["sector"] below.
+  rename_industry_carriers: {"Electricity": "electricity", "Biofuels": "solid biomass", "Heat": "low-temperature heat", "Natural Gas": "gas", "Coal": "coal", "Hydrogen": "hydrogen", "Oil": "oil"}
+
+costs: # Costs used in PyPSA-Earth-Sec. Year depends on the wildcard planning_horizon in the scenario section
+  version: v0.9.2
+  lifetime: 25 #default lifetime
+  # From a Lion Hirth paper, also reflects average of Noothout et al 2016
+  discountrate: [0.1] #, 0.086, 0.111]
+  # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html # noqa: E501
+  USD2013_to_EUR2013: 0.7532
+
+  # Marginal and capital costs can be overwritten
+  # capital_cost:
+  #   onwind: 500
+  marginal_cost:
+    solar: 0.01
+    onwind: 0.015
+    offwind: 0.015
+    hydro: 0.
+    H2: 0.
+    battery: 0.
+
+  electrolyzer_cc: [0.5, 1]
+
+  emission_prices: # only used with the option Ep (emission prices)
+    co2: 0.
+
+  lines:
+    length_factor: 1.25 #to estimate offwind connection costs
+
+
+industry:
+  St_primary_fraction: 0.9 # fraction of steel produced via primary route versus secondary route (scrap+EAF); today fraction is 0.6
+    # 2020: 0.6
+    # 2025: 0.55
+    # 2030: 0.5
+    # 2035: 0.45
+    # 2040: 0.4
+    # 2045: 0.35
+    # 2050: 0.3
+  DRI_fraction: 0.5 # fraction of the primary route converted to DRI + EAF
+    # 2020: 0
+    # 2025: 0
+    # 2030: 0.05
+    # 2035: 0.2
+    # 2040: 0.4
+    # 2045: 0.7
+    # 2050: 1
+  H2_DRI: 1.7   #H2 consumption in Direct Reduced Iron (DRI),  MWh_H2,LHV/ton_Steel from 51kgH2/tSt in Vogl et al (2018) doi:10.1016/j.jclepro.2018.08.279
+  elec_DRI: 0.322   #electricity consumption in Direct Reduced Iron (DRI) shaft, MWh/tSt HYBRIT brochure https://ssabwebsitecdn.azureedge.net/-/media/hybrit/files/hybrit_brochure.pdf
+  Al_primary_fraction: 0.2 # fraction of aluminium produced via the primary route versus scrap; today fraction is 0.4
+    # 2020: 0.4
+    # 2025: 0.375
+    # 2030: 0.35
+    # 2035: 0.325
+    # 2040: 0.3
+    # 2045: 0.25
+    # 2050: 0.2
+  MWh_CH4_per_tNH3_SMR: 10.8 # 2012's demand from https://ec.europa.eu/docsroom/documents/4165/attachments/1/translations/en/renditions/pdf
+  MWh_elec_per_tNH3_SMR: 0.7 # same source, assuming 94-6% split methane-elec of total energy demand 11.5 MWh/tNH3
+  MWh_H2_per_tNH3_electrolysis: 6.5 # from https://doi.org/10.1016/j.joule.2018.04.017, around 0.197 tH2/tHN3 (>3/17 since some H2 lost and used for energy)
+  MWh_elec_per_tNH3_electrolysis: 1.17 # from https://doi.org/10.1016/j.joule.2018.04.017 Table 13 (air separation and HB)
+  NH3_process_emissions: 24.5 # in MtCO2/a from SMR for H2 production for NH3 from UNFCCC for 2015 for EU28
+  petrochemical_process_emissions: 25.5 # in MtCO2/a for petrochemical and other from UNFCCC for 2015 for EU28
+  HVC_primary_fraction: 1. # fraction of today's HVC produced via primary route
+  HVC_mechanical_recycling_fraction: 0. # fraction of today's HVC produced via mechanical recycling
+  HVC_chemical_recycling_fraction: 0. # fraction of today's HVC produced via chemical recycling
+  HVC_production_today: 52. # MtHVC/a from DECHEMA (2017), Figure 16, page 107; includes ethylene, propylene and BTX
+  MWh_elec_per_tHVC_mechanical_recycling: 0.547 # from SI of https://doi.org/10.1016/j.resconrec.2020.105010, Table S5, for HDPE, PP, PS, PET. LDPE would be 0.756.
+  MWh_elec_per_tHVC_chemical_recycling: 6.9 # Material Economics (2019), page 125; based on pyrolysis and electric steam cracking
+  chlorine_production_today: 9.58 # MtCl/a from DECHEMA (2017), Table 7, page 43
+  MWh_elec_per_tCl: 3.6 # DECHEMA (2017), Table 6, page 43
+  MWh_H2_per_tCl: -0.9372  # DECHEMA (2017), page 43; negative since hydrogen produced in chloralkali process
+  methanol_production_today: 1.5 # MtMeOH/a from DECHEMA (2017), page 62
+  MWh_elec_per_tMeOH: 0.167 # DECHEMA (2017), Table 14, page 65
+  MWh_CH4_per_tMeOH: 10.25 # DECHEMA (2017), Table 14, page 65
+  hotmaps_locate_missing: false
+  reference_year: 2015
+
+solar_thermal:
+  clearsky_model: simple
+  orientation:
+    slope: 45.
+    azimuth: 180.
+
+existing_capacities:
+  grouping_years_power: [1960, 1965, 1970, 1975, 1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025, 2030]
+  grouping_years_heat: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2019] # these should not extend 2020
+  threshold_capacity: 10
+  default_heating_lifetime: 20
+  conventional_carriers:
+  - lignite
+  - coal
+  - oil
+  - uranium
+
+sector:
+  gas:
+    spatial_gas: true # ALWAYS TRUE
+    network: false # ALWAYS FALSE for now (NOT USED)
+    network_data: GGIT # Global dataset -> 'GGIT' , European dataset -> 'IGGIELGN'
+    network_data_GGIT_status: ['Construction', 'Operating', 'Idle', 'Shelved', 'Mothballed', 'Proposed']
+  hydrogen:
+    network: true
+    network_limit: 25000 #GWkm
+    network_routes: greenfield # "gas or "greenfield". If "gas"  ->  the network data are fetched from ["sector"]["gas"]["network_data"]. If "greenfield"  -> the network follows the topology of electrical transmission lines
+    gas_network_repurposing: true # If true -> ["sector"]["gas"]["network"] is automatically false
+    underground_storage: false
+    hydrogen_colors: false
+    set_color_shares: false
+    blue_share: 0.40
+    pink_share: 0.05
+  coal:
+    shift_to_elec: true # If true, residential and services demand of coal is shifted to electricity. If false, the final energy demand of coal is disregarded
+  international_bunkers: false #Whether or not to count the emissions of international aviation and navigation
+
+  oil:
+    spatial_oil: true
+
+  district_heating:
+    potential: 0.3 #maximum fraction of urban demand which can be supplied by district heating
+      #increase of today's district heating demand to potential maximum district heating share
+      #progress = 0 means today's district heating share, progress=-1 means maxumzm fraction of urban demand is supplied by district heating
+    progress: 1
+      #2020: 0.0
+      #2030: 0.3
+      #2040: 0.6
+      #2050: 1.0
+    district_heating_loss: 0.15
+  reduce_space_heat_exogenously: true  # reduces space heat demand by a given factor (applied before losses in DH)
+  # this can represent e.g. building renovation, building demolition, or if
+  # the factor is negative: increasing floor area, increased thermal comfort, population growth
+  reduce_space_heat_exogenously_factor: 0.29 # per unit reduction in space heat demand
+  # the default factors are determined by the LTS scenario from http://tool.european-calculator.eu/app/buildings/building-types-area/?levers=1ddd4444421213bdbbbddd44444ffffff11f411111221111211l212221
+    # 2020: 0.10  # this results in a space heat demand reduction of 10%
+    # 2025: 0.09  # first heat demand increases compared to 2020 because of larger floor area per capita
+    # 2030: 0.09
+    # 2035: 0.11
+    # 2040: 0.16
+    # 2045: 0.21
+    # 2050: 0.29
+  tes: true
+  tes_tau: # 180 day time constant for centralised, 3 day for decentralised
+    decentral: 3
+    central: 180
+  boilers: true
+  oil_boilers: false
+  chp: true
+  micro_chp: false
+  solar_thermal: true
+  heat_pump_sink_T: 55 #Celsius, based on DTU / large area radiators; used un build_cop_profiles.py
+  time_dep_hp_cop: true #time dependent heat pump coefficient of performance
+  solar_cf_correction: 0.788457 # = >>>1/1.2683
+  bev_plug_to_wheel_efficiency: 0.2 #kWh/km from EPA https://www.fueleconomy.gov/feg/ for Tesla Model S
+  bev_charge_efficiency: 0.9 #BEV (dis-)charging efficiency
+  transport_heating_deadband_upper: 20.
+  transport_heating_deadband_lower: 15.
+  ICE_lower_degree_factor: 0.375 #in per cent increase in fuel consumption per degree above deadband
+  ICE_upper_degree_factor: 1.6
+  EV_lower_degree_factor: 0.98
+  EV_upper_degree_factor: 0.63
+  bev_avail_max: 0.95
+  bev_avail_mean: 0.8
+  bev_dsm_restriction_value: 0.75 #Set to 0 for no restriction on BEV DSM
+  bev_dsm_restriction_time: 7 #Time at which SOC of BEV has to be dsm_restriction_value
+  v2g: true #allows feed-in to grid from EV battery
+  bev_dsm: true #turns on EV battery
+  bev_energy: 0.05 #average battery size in MWh
+  bev_availability: 0.5 #How many cars do smart charging
+  transport_fuel_cell_efficiency: 1
+  transport_internal_combustion_efficiency: 1
+  industry_util_factor: 0.7
+
+  biomass_transport: true  # biomass transport between nodes
+  biomass_transport_default_cost: 0.1 #EUR/km/MWh
+  solid_biomass_potential: 3604 # 4805 TWh/a for all bioenergy sources according to Welfle (2017), 75% solid, 0.28% gaseous according to IEA (2021)
+  biogas_potential: 13.5 # TWh/a, Potential of whole modelled area
+  biomass_to_liquid: true
+
+  efficiency_heat_oil_to_elec: 0.9
+  efficiency_heat_biomass_to_elec: 0.9
+  efficiency_heat_gas_to_elec: 0.9
+
+  dynamic_transport:
+    enable: false # If "True", then the BEV and FCEV shares are obtained depening on the "Co2L"-wildcard (e.g. "Co2L0.70: 0.10"). If "False", then the shares are obtained depending on the "demand" wildcard and "planning_horizons" wildcard as listed below (e.g. "DF_2050: 0.08")
+    land_transport_electric_share:
+      Co2L2.0: 0.00
+      Co2L1.0: 0.01
+      Co2L0.90: 0.03
+      Co2L0.80: 0.06
+      Co2L0.70: 0.10
+      Co2L0.60: 0.17
+      Co2L0.50: 0.27
+      Co2L0.40: 0.40
+      Co2L0.30: 0.55
+      Co2L0.20: 0.69
+      Co2L0.10: 0.80
+      Co2L0.00: 0.88
+    land_transport_fuel_cell_share:
+      Co2L2.0: 0.01
+      Co2L1.0: 0.01
+      Co2L0.90: 0.01
+      Co2L0.80: 0.01
+      Co2L0.70: 0.01
+      Co2L0.60: 0.01
+      Co2L0.50: 0.01
+      Co2L0.40: 0.01
+      Co2L0.30: 0.01
+      Co2L0.20: 0.01
+      Co2L0.10: 0.01
+      Co2L0.00: 0.01
+    bio_transport_share:
+      Co2L2.0: 0.01
+      Co2L1.0: 0.01
+      Co2L0.90: 0.01
+      Co2L0.80: 0.01
+      Co2L0.70: 0.01
+      Co2L0.60: 0.01
+      Co2L0.50: 0.01
+      Co2L0.40: 0.01
+      Co2L0.30: 0.01
+      Co2L0.20: 0.01
+      Co2L0.10: 0.01
+      Co2L0.00: 0.01
+
+  land_transport_fuel_cell_share: # 1 means all FCEVs HERE
+    BI_2030: 0.007
+    GH_2030: 0.036
+    DE_2030: 0.00
+    BI_2035: 0.026
+    GH_2035: 0.133
+    DE_2035: 0.00
+    BI_2040: 0.063
+    GH_2040: 0.266
+    DE_2040: 0.00
+    BI_2045: 0.113
+    GH_2045: 0.410
+    DE_2045: 0.021
+    BI_2050: 0.210
+    GH_2050: 0.584
+    DE_2050: 0.056
+
+  land_transport_electric_share: # 1 means all EVs  # This leads to problems when non-zero HERE
+    BI_2030: 0.022
+    GH_2030: 0.018
+    DE_2030: 0.038
+    BI_2035: 0.067
+    GH_2035: 0.054
+    DE_2035: 0.133
+    BI_2040: 0.117
+    GH_2040: 0.090
+    DE_2040: 0.264
+    BI_2045: 0.190
+    GH_2045: 0.164
+    DE_2045: 0.457
+    BI_2050: 0.301
+    GH_2050: 0.263
+    DE_2050: 0.742
+
+  bio_transport_share: # 1 means all EVs  # This leads to problems when non-zero HERE
+    BI_2030: 0.261
+    GH_2030: 0.231
+    DE_2030: 0.235
+    BI_2035: 0.343
+    GH_2035: 0.237
+    DE_2035: 0.253
+    BI_2040: 0.414
+    GH_2040: 0.222
+    DE_2040: 0.254
+    BI_2045: 0.491
+    GH_2045: 0.213
+    DE_2045: 0.261
+    BI_2050: 0.433
+    GH_2050: 0.093
+    DE_2050: 0.123
+
+
+
+  co2_network: true
+  co2_sequestration_potential: 70 #MtCO2/a sequestration potential for Europe
+  co2_sequestration_cost: 10 #EUR/tCO2 for sequestration of CO2
+  hydrogen_underground_storage: false
+  shipping_hydrogen_liquefaction: false
+  shipping_average_efficiency: 0.575 #For conversion of fuel oil to propulsion in 2011
+
+  shipping_hydrogen_share: #1.0
+    BI_2030: 0.0
+    GH_2030: 0.0
+    DE_2030: 0.0
+    BI_2035: 0.014
+    GH_2035: 0.014
+    DE_2035: 0.014
+    BI_2040: 0.064
+    GH_2040: 0.064
+    DE_2040: 0.065
+    BI_2045: 0.128
+    GH_2045: 0.130
+    DE_2045: 0.131
+    BI_2050: 0.240
+    GH_2050: 0.248
+    DE_2050: 0.254
+
+  gadm_level: 1
+  marginal_cost_storage: 0
+  methanation: true
+  helmeth: true
+  dac: true
+  SMR: true
+  SMR CC: true
+  cc_fraction: 0.9
+  cc: true
+  space_heat_share: 0.6 # the share of space heating from all heating. Remainder goes to water heating.
+  airport_sizing_factor: 3
+
+  min_part_load_fischer_tropsch: 0.9
+
+  conventional_generation: # generator : carrier
+    OCGT: gas
+    #Gen_Test: oil # Just for testing purposes
+
+# snapshots are originally set in PyPSA-Earth/config.yaml but used again by PyPSA-Earth-Sec
+snapshots:
+  # arguments to pd.date_range
+  start: "2013-01-01"
+  end: "2014-01-01"
+  inclusive: "left" # end is not inclusive
+
+# atlite:
+#   cutout: ./cutouts/africa-2013-era5.nc
+
+build_osm_network:  # TODO: To Remove this once we merge pypsa-earth and pypsa-earth-sec
+  force_ac: true  # When true, it forces all components (lines and substation) to be AC-only. To be used if DC assets create problem.
+
+solving:
+  #tmpdir: "path/to/tmp"
+  options:
+    formulation: kirchhoff
+    clip_p_max_pu: 1.e-2
+    load_shedding: false
+    noisy_costs: true
+    skip_iterations: true
+    track_iterations: false
+    min_iterations: 4
+    max_iterations: 6
+
+  solver:
+    name: gurobi
+    threads: 25
+    method: 2 # barrier
+    crossover: 0
+    BarConvTol: 1.e-6
+    Seed: 123
+    AggFill: 0
+    PreDual: 0
+    GURO_PAR_BARDENSETHRESH: 200
+    #FeasibilityTol: 1.e-6
+
+  mem: 30000 #memory in MB; 20 GB enough for 50+B+I+H2; 100 GB for 181+B+I+H2
+
+plotting:
+  map:
+    boundaries: [-11, 30, 34, 71]
+    color_geomap:
+      ocean: white
+      land: whitesmoke
+  costs_max: 10
+  costs_threshold: 0.2
+  energy_max: 20000
+  energy_min: -20000
+  energy_threshold: 15
+  vre_techs:
+  - onwind
+  - offwind-ac
+  - offwind-dc
+  - solar
+  - ror
+  renewable_storage_techs:
+  - PHS
+  - hydro
+  conv_techs:
+  - OCGT
+  - CCGT
+  - Nuclear
+  - Coal
+  storage_techs:
+  - hydro+PHS
+  - battery
+  - H2
+  load_carriers:
+  - AC load
+  AC_carriers:
+  - AC line
+  - AC transformer
+  link_carriers:
+  - DC line
+  - Converter AC-DC
+  heat_links:
+  - heat pump
+  - resistive heater
+  - CHP heat
+  - CHP electric
+  - gas boiler
+  - central heat pump
+  - central resistive heater
+  - central CHP heat
+  - central CHP electric
+  - central gas boiler
+  heat_generators:
+  - gas boiler
+  - central gas boiler
+  - solar thermal collector
+  - central solar thermal collector
+  tech_colors:
+    SMR CC: "darkblue"
+    gas for industry CC: "brown"
+    process emissions CC: "gray"
+    CO2 pipeline: "gray"
+    onwind: "dodgerblue"
+    onwind2: "dodgerblue"
+    onwind3: "dodgerblue"
+    onwind4: "dodgerblue"
+    onshore wind: "#235ebc"
+    offwind: "#6895dd"
+    offshore wind: "#6895dd"
+    offwind-ac: "c"
+    offshore wind (AC): "#6895dd"
+    offwind-dc: "#74c6f2"
+    offshore wind (DC): "#74c6f2"
+    wave: '#004444'
+    hydro: '#3B5323'
+    hydro reservoir: '#3B5323'
+    ror: '#78AB46'
+    run of river: '#78AB46'
+    hydroelectricity: 'blue'
+    solar: "orange"
+    solar PV: "#f9d002"
+    solar thermal: coral
+    solar rooftop: '#ffef60'
+    OCGT: wheat
+    OCGT marginal: sandybrown
+    OCGT-heat: '#ee8340'
+    gas boiler: '#ee8340'
+    gas boilers: '#ee8340'
+    gas boiler marginal: '#ee8340'
+    gas-to-power/heat: 'brown'
+    gas: brown
+    natural gas: brown
+    SMR: '#4F4F2F'
+    oil: '#B5A642'
+    oil EOP: '#B5A642'
+    oil boiler: '#B5A677'
+    lines: k
+    transmission lines: k
+    H2: m
+    H2 electrolysis: m
+    H2 liquefaction: m
+    hydrogen storage: m
+    battery: slategray
+    battery storage: slategray
+    home battery: '#614700'
+    home battery storage: '#614700'
+    Nuclear: r
+    Nuclear marginal: r
+    nuclear: r
+    uranium: r
+    Coal: k
+    coal: k
+    industry coal emissions: '#444444'
+    Coal marginal: k
+    Lignite: grey
+    lignite: grey
+    Lignite marginal: grey
+    CCGT: '#ee8340'
+    CCGT marginal: '#ee8340'
+    heat pumps: '#76EE00'
+    heat pump: '#76EE00'
+    air heat pump: '#76EE00'
+    ground heat pump: '#40AA00'
+    power-to-heat: 'red'
+    resistive heater: pink
+    Sabatier: '#FF1493'
+    methanation: '#FF1493'
+    power-to-gas: 'purple'
+    power-to-liquid: 'darkgreen'
+    helmeth: '#7D0552'
+    DAC: 'deeppink'
+    co2 stored: '#123456'
+    CO2 sequestration: '#123456'
+    CC: k
+    co2: '#123456'
+    co2 vent: '#654321'
+    agriculture heat: '#D07A7A'
+    agriculture oil: '#1e1e1e'
+    agriculture machinery oil: '#1e1e1e'
+    agriculture machinery oil emissions: '#111111'
+    agriculture electricity: '#222222'
+    solid biomass for industry co2 from atmosphere: '#654321'
+    solid biomass for industry co2 to stored: '#654321'
+    solid biomass for industry CC: '#654321'
+    gas for industry co2 to atmosphere: '#654321'
+    gas emissions: '#654321'
+    gas for industry co2 to stored: '#654321'
+    Fischer-Tropsch: '#44DD33'
+    kerosene for aviation: '#44BB11'
+    naphtha for industry: '#44FF55'
+    land transport oil: '#44DD33'
+    rail transport oil: '#44DD33'
+    water tanks: '#BBBBBB'
+    hot water storage: '#BBBBBB'
+    hot water charging: '#BBBBBB'
+    hot water discharging: '#999999'
+    # CO2 pipeline: '#999999'
+    CHP: r
+    CHP heat: r
+    CHP electric: r
+    PHS: g
+    Ambient: k
+    Electric load: b
+    Heat load: r
+    heat: darkred
+    rural heat: '#880000'
+    central heat: '#b22222'
+    decentral heat: '#800000'
+    low-temperature heat for industry: '#991111'
+    process heat: '#FF3333'
+    heat demand: darkred
+    electric demand: k
+    Li ion: grey
+    district heating: '#CC4E5C'
+    retrofitting: purple
+    building retrofitting: purple
+    BEV charger: grey
+    V2G: grey
+    land transport EV: grey
+    electricity: k
+    gas for industry: '#333333'
+    solid biomass for industry: '#555555'
+    industry electricity: '#222222'
+    industry new electricity: '#222222'
+    process emissions to stored: '#444444'
+    process emissions to atmosphere: '#888888'
+    process emissions: '#222222'
+    oil emissions: '#666666'
+    industry oil emissions: '#666666'
+    land transport oil emissions: '#666666'
+    land transport fuel cell: '#AAAAAA'
+    biogas: '#800000'
+    solid biomass: '#DAA520'
+    today: '#D2691E'
+    shipping: '#6495ED'
+    shipping oil: "#6495ED"
+    shipping oil emissions: "#6495ED"
+    electricity distribution grid: 'y'
+    solid biomass transport: green
+    H2 for industry: "#222222"
+    H2 for shipping: "#6495ED"
+    biomass EOP: "green"
+    biomass: "green"
+    high-temp electrolysis: "magenta"
+    oil pipeline: "grey"
+    agriculture biomass: "green"
+    biomass to liquid: "green"
+    H2 pipeline: m

--- a/config.bright_high.yaml
+++ b/config.bright_high.yaml
@@ -43,8 +43,7 @@ policy_config:
     limit_SMR_dispatch: true # Limits the dispatch of SMR to the reference case
     re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
   renewables:
-      ratio_rooftop_to_utility_solar:  # insert value to activate, leave empty to disable
-      
+    ratio_rooftop_to_utility_solar:    # insert value to activate, leave empty to disable
 clustering_options:
   alternative_clustering: true
 

--- a/config.bright_low.yaml
+++ b/config.bright_low.yaml
@@ -1,0 +1,656 @@
+logging_level: INFO
+tutorial: false
+
+results_dir: results/
+summary_dir: results/
+costs_dir: data/ #TODO change to the equivalent of technology data
+
+run:
+  name: 241107_ir_sensitivity
+  name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
+  shared_cutouts: true  # set to true to share the default cutout(s) across runs
+                        # Note: value false requires build_cutout to be enabled
+
+foresight: overnight
+
+# option to disable the subworkflow to ease the analyses
+disable_subworkflow: false
+
+scenario:
+  simpl: # only relevant for PyPSA-Eur
+  - ""
+  clusters: # number of nodes in Europe, any integer between 37 (1 node per country-zone) and several hundred
+  - 11
+  planning_horizons: # investment years for myopic and perfect; or costs year for overnight
+  - 2035
+  ll:
+  - "v1.0"
+  opts:
+  - "Co2L"
+  sopts:
+  - "3H"
+  demand: ["BI", "DE", "GH"] # BI/DE/GH
+
+policy_config:
+  hydrogen:
+    temporal_matching: "hour" #either "hour", "month", "year", "no_res_matching"
+    spatial_matching: false
+    additionality: true # RE electricity is equal to the amount required for additional hydrogen export compared to the 0 export case ("reference_case")
+    allowed_excess: 1.0
+    is_reference: false # Whether or not this network is a reference case network, relevant only if additionality is _true_
+    remove_h2_load: false #Whether or not to remove the h2 load from the network, relevant only if is_reference is _true_
+    path_to_ref: "/scratch/htc/cschauss/BRIGHT/submodules/pypsa-earth-sec/results/241107_ir_sensitivity/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.065_scenario_0export_endogenousmp.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
+    limit_SMR_dispatch: true # Limits the dispatch of SMR to the reference case
+    re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
+  renewables:
+      ratio_rooftop_to_utility_solar:  # insert value to activate, leave empty to disable
+
+clustering_options:
+  alternative_clustering: true
+
+countries: ['BR']
+
+demand_data:
+  update_data: true # if true, the workflow downloads the energy balances data saved in data/demand/unsd/data again. Turn on for the first run.
+  base_year: 2019
+
+  other_industries: false # Whether or not to include industries that are not specified. some countries have has exageratted numbers, check carefully.
+  aluminium_year: 2019 # Year of the aluminium demand data specified in `data/AL_production.csv`
+
+
+enable:
+  retrieve_cost_data: true # if true, the workflow overwrites the cost data saved in data/costs again
+
+fossil_reserves:
+  oil: 2000 #TWh Maybe reduntant
+
+
+export:
+  h2export: "endogenous" #,20,30,40,50,60,70,80,90,100] or "endogenous" in combination with h2mp # Yearly export demand in TWh
+  h2mp: [70, 72.5, 75, 77.5, 80, 82.5, 85, 87.5, 90] # Global hydrogen market price in EUR/MWh if h2export is set to endogenous
+  store: false # [True, False] # specifies wether an export store to balance demand is implemented
+  store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
+  export_profile: "constant" # use "ship" or "constant"
+  constant_nodal_export: true
+  ship:
+    ship_capacity: 0.4 # TWh # 0.05 TWh for new ones, 0.003 TWh for Susio Frontier, 0.4 TWh according to Hampp2021: "Corresponds to 11360 t H2 (l) with LHV of 33.3333 Mwh/t_H2. Cihlar et al 2020 based on IEA 2019, Table 3-B"
+    travel_time: 288 # hours # From Agadir to Rotterdam and back (12*24)
+    fill_time: 24 # hours, for 48h see Hampp2021
+    unload_time: 24 # hours for 48h see Hampp2021
+
+custom_data:
+  renewables_enertile: [ "solar-rooftop", "onwind", "onwind_rest", "solar"]
+  renewables: ["solar-rooftop", "onwind", "onwind2", "onwind3", "onwind4", "solar"] # ['csp', 'rooftop-solar', 'solar']
+  energy_totals: true
+  elec_demand: true
+  heat_demand: false
+  industry_demand: true
+  industry_database: true
+  transport_demand: false
+  water_costs: false
+  h2_underground: false
+  add_existing: false
+  custom_sectors: false
+  gas_network: false # If "True" then a custom .csv file must be placed in "resources/custom_data/pipelines.csv" , If "False" the user can choose btw "greenfield" or Model built-in datasets. Please refer to ["sector"] below.
+  rename_industry_carriers: {"Electricity": "electricity", "Biofuels": "solid biomass", "Heat": "low-temperature heat", "Natural Gas": "gas", "Coal": "coal", "Hydrogen": "hydrogen", "Oil": "oil"}
+
+costs: # Costs used in PyPSA-Earth-Sec. Year depends on the wildcard planning_horizon in the scenario section
+  version: v0.9.2
+  lifetime: 25 #default lifetime
+  # From a Lion Hirth paper, also reflects average of Noothout et al 2016
+  discountrate: [0.06] #, 0.086, 0.111]
+  # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html # noqa: E501
+  USD2013_to_EUR2013: 0.7532
+
+  # Marginal and capital costs can be overwritten
+  # capital_cost:
+  #   onwind: 500
+  marginal_cost:
+    solar: 0.01
+    onwind: 0.015
+    offwind: 0.015
+    hydro: 0.
+    H2: 0.
+    battery: 0.
+
+  electrolyzer_cc: [0.5, 1]
+
+  emission_prices: # only used with the option Ep (emission prices)
+    co2: 0.
+
+  lines:
+    length_factor: 1.25 #to estimate offwind connection costs
+
+
+industry:
+  St_primary_fraction: 0.9 # fraction of steel produced via primary route versus secondary route (scrap+EAF); today fraction is 0.6
+    # 2020: 0.6
+    # 2025: 0.55
+    # 2030: 0.5
+    # 2035: 0.45
+    # 2040: 0.4
+    # 2045: 0.35
+    # 2050: 0.3
+  DRI_fraction: 0.5 # fraction of the primary route converted to DRI + EAF
+    # 2020: 0
+    # 2025: 0
+    # 2030: 0.05
+    # 2035: 0.2
+    # 2040: 0.4
+    # 2045: 0.7
+    # 2050: 1
+  H2_DRI: 1.7   #H2 consumption in Direct Reduced Iron (DRI),  MWh_H2,LHV/ton_Steel from 51kgH2/tSt in Vogl et al (2018) doi:10.1016/j.jclepro.2018.08.279
+  elec_DRI: 0.322   #electricity consumption in Direct Reduced Iron (DRI) shaft, MWh/tSt HYBRIT brochure https://ssabwebsitecdn.azureedge.net/-/media/hybrit/files/hybrit_brochure.pdf
+  Al_primary_fraction: 0.2 # fraction of aluminium produced via the primary route versus scrap; today fraction is 0.4
+    # 2020: 0.4
+    # 2025: 0.375
+    # 2030: 0.35
+    # 2035: 0.325
+    # 2040: 0.3
+    # 2045: 0.25
+    # 2050: 0.2
+  MWh_CH4_per_tNH3_SMR: 10.8 # 2012's demand from https://ec.europa.eu/docsroom/documents/4165/attachments/1/translations/en/renditions/pdf
+  MWh_elec_per_tNH3_SMR: 0.7 # same source, assuming 94-6% split methane-elec of total energy demand 11.5 MWh/tNH3
+  MWh_H2_per_tNH3_electrolysis: 6.5 # from https://doi.org/10.1016/j.joule.2018.04.017, around 0.197 tH2/tHN3 (>3/17 since some H2 lost and used for energy)
+  MWh_elec_per_tNH3_electrolysis: 1.17 # from https://doi.org/10.1016/j.joule.2018.04.017 Table 13 (air separation and HB)
+  NH3_process_emissions: 24.5 # in MtCO2/a from SMR for H2 production for NH3 from UNFCCC for 2015 for EU28
+  petrochemical_process_emissions: 25.5 # in MtCO2/a for petrochemical and other from UNFCCC for 2015 for EU28
+  HVC_primary_fraction: 1. # fraction of today's HVC produced via primary route
+  HVC_mechanical_recycling_fraction: 0. # fraction of today's HVC produced via mechanical recycling
+  HVC_chemical_recycling_fraction: 0. # fraction of today's HVC produced via chemical recycling
+  HVC_production_today: 52. # MtHVC/a from DECHEMA (2017), Figure 16, page 107; includes ethylene, propylene and BTX
+  MWh_elec_per_tHVC_mechanical_recycling: 0.547 # from SI of https://doi.org/10.1016/j.resconrec.2020.105010, Table S5, for HDPE, PP, PS, PET. LDPE would be 0.756.
+  MWh_elec_per_tHVC_chemical_recycling: 6.9 # Material Economics (2019), page 125; based on pyrolysis and electric steam cracking
+  chlorine_production_today: 9.58 # MtCl/a from DECHEMA (2017), Table 7, page 43
+  MWh_elec_per_tCl: 3.6 # DECHEMA (2017), Table 6, page 43
+  MWh_H2_per_tCl: -0.9372  # DECHEMA (2017), page 43; negative since hydrogen produced in chloralkali process
+  methanol_production_today: 1.5 # MtMeOH/a from DECHEMA (2017), page 62
+  MWh_elec_per_tMeOH: 0.167 # DECHEMA (2017), Table 14, page 65
+  MWh_CH4_per_tMeOH: 10.25 # DECHEMA (2017), Table 14, page 65
+  hotmaps_locate_missing: false
+  reference_year: 2015
+
+solar_thermal:
+  clearsky_model: simple
+  orientation:
+    slope: 45.
+    azimuth: 180.
+
+existing_capacities:
+  grouping_years_power: [1960, 1965, 1970, 1975, 1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025, 2030]
+  grouping_years_heat: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2019] # these should not extend 2020
+  threshold_capacity: 10
+  default_heating_lifetime: 20
+  conventional_carriers:
+  - lignite
+  - coal
+  - oil
+  - uranium
+
+sector:
+  gas:
+    spatial_gas: true # ALWAYS TRUE
+    network: false # ALWAYS FALSE for now (NOT USED)
+    network_data: GGIT # Global dataset -> 'GGIT' , European dataset -> 'IGGIELGN'
+    network_data_GGIT_status: ['Construction', 'Operating', 'Idle', 'Shelved', 'Mothballed', 'Proposed']
+  hydrogen:
+    network: true
+    network_limit: 25000 #GWkm
+    network_routes: greenfield # "gas or "greenfield". If "gas"  ->  the network data are fetched from ["sector"]["gas"]["network_data"]. If "greenfield"  -> the network follows the topology of electrical transmission lines
+    gas_network_repurposing: true # If true -> ["sector"]["gas"]["network"] is automatically false
+    underground_storage: false
+    hydrogen_colors: false
+    set_color_shares: false
+    blue_share: 0.40
+    pink_share: 0.05
+  coal:
+    shift_to_elec: true # If true, residential and services demand of coal is shifted to electricity. If false, the final energy demand of coal is disregarded
+  international_bunkers: false #Whether or not to count the emissions of international aviation and navigation
+
+  oil:
+    spatial_oil: true
+
+  district_heating:
+    potential: 0.3 #maximum fraction of urban demand which can be supplied by district heating
+      #increase of today's district heating demand to potential maximum district heating share
+      #progress = 0 means today's district heating share, progress=-1 means maxumzm fraction of urban demand is supplied by district heating
+    progress: 1
+      #2020: 0.0
+      #2030: 0.3
+      #2040: 0.6
+      #2050: 1.0
+    district_heating_loss: 0.15
+  reduce_space_heat_exogenously: true  # reduces space heat demand by a given factor (applied before losses in DH)
+  # this can represent e.g. building renovation, building demolition, or if
+  # the factor is negative: increasing floor area, increased thermal comfort, population growth
+  reduce_space_heat_exogenously_factor: 0.29 # per unit reduction in space heat demand
+  # the default factors are determined by the LTS scenario from http://tool.european-calculator.eu/app/buildings/building-types-area/?levers=1ddd4444421213bdbbbddd44444ffffff11f411111221111211l212221
+    # 2020: 0.10  # this results in a space heat demand reduction of 10%
+    # 2025: 0.09  # first heat demand increases compared to 2020 because of larger floor area per capita
+    # 2030: 0.09
+    # 2035: 0.11
+    # 2040: 0.16
+    # 2045: 0.21
+    # 2050: 0.29
+  tes: true
+  tes_tau: # 180 day time constant for centralised, 3 day for decentralised
+    decentral: 3
+    central: 180
+  boilers: true
+  oil_boilers: false
+  chp: true
+  micro_chp: false
+  solar_thermal: true
+  heat_pump_sink_T: 55 #Celsius, based on DTU / large area radiators; used un build_cop_profiles.py
+  time_dep_hp_cop: true #time dependent heat pump coefficient of performance
+  solar_cf_correction: 0.788457 # = >>>1/1.2683
+  bev_plug_to_wheel_efficiency: 0.2 #kWh/km from EPA https://www.fueleconomy.gov/feg/ for Tesla Model S
+  bev_charge_efficiency: 0.9 #BEV (dis-)charging efficiency
+  transport_heating_deadband_upper: 20.
+  transport_heating_deadband_lower: 15.
+  ICE_lower_degree_factor: 0.375 #in per cent increase in fuel consumption per degree above deadband
+  ICE_upper_degree_factor: 1.6
+  EV_lower_degree_factor: 0.98
+  EV_upper_degree_factor: 0.63
+  bev_avail_max: 0.95
+  bev_avail_mean: 0.8
+  bev_dsm_restriction_value: 0.75 #Set to 0 for no restriction on BEV DSM
+  bev_dsm_restriction_time: 7 #Time at which SOC of BEV has to be dsm_restriction_value
+  v2g: true #allows feed-in to grid from EV battery
+  bev_dsm: true #turns on EV battery
+  bev_energy: 0.05 #average battery size in MWh
+  bev_availability: 0.5 #How many cars do smart charging
+  transport_fuel_cell_efficiency: 1
+  transport_internal_combustion_efficiency: 1
+  industry_util_factor: 0.7
+
+  biomass_transport: true  # biomass transport between nodes
+  biomass_transport_default_cost: 0.1 #EUR/km/MWh
+  solid_biomass_potential: 3604 # 4805 TWh/a for all bioenergy sources according to Welfle (2017), 75% solid, 0.28% gaseous according to IEA (2021)
+  biogas_potential: 13.5 # TWh/a, Potential of whole modelled area
+  biomass_to_liquid: true
+
+  efficiency_heat_oil_to_elec: 0.9
+  efficiency_heat_biomass_to_elec: 0.9
+  efficiency_heat_gas_to_elec: 0.9
+
+  dynamic_transport:
+    enable: false # If "True", then the BEV and FCEV shares are obtained depening on the "Co2L"-wildcard (e.g. "Co2L0.70: 0.10"). If "False", then the shares are obtained depending on the "demand" wildcard and "planning_horizons" wildcard as listed below (e.g. "DF_2050: 0.08")
+    land_transport_electric_share:
+      Co2L2.0: 0.00
+      Co2L1.0: 0.01
+      Co2L0.90: 0.03
+      Co2L0.80: 0.06
+      Co2L0.70: 0.10
+      Co2L0.60: 0.17
+      Co2L0.50: 0.27
+      Co2L0.40: 0.40
+      Co2L0.30: 0.55
+      Co2L0.20: 0.69
+      Co2L0.10: 0.80
+      Co2L0.00: 0.88
+    land_transport_fuel_cell_share:
+      Co2L2.0: 0.01
+      Co2L1.0: 0.01
+      Co2L0.90: 0.01
+      Co2L0.80: 0.01
+      Co2L0.70: 0.01
+      Co2L0.60: 0.01
+      Co2L0.50: 0.01
+      Co2L0.40: 0.01
+      Co2L0.30: 0.01
+      Co2L0.20: 0.01
+      Co2L0.10: 0.01
+      Co2L0.00: 0.01
+    bio_transport_share:
+      Co2L2.0: 0.01
+      Co2L1.0: 0.01
+      Co2L0.90: 0.01
+      Co2L0.80: 0.01
+      Co2L0.70: 0.01
+      Co2L0.60: 0.01
+      Co2L0.50: 0.01
+      Co2L0.40: 0.01
+      Co2L0.30: 0.01
+      Co2L0.20: 0.01
+      Co2L0.10: 0.01
+      Co2L0.00: 0.01
+
+  land_transport_fuel_cell_share: # 1 means all FCEVs HERE
+    BI_2030: 0.007
+    GH_2030: 0.036
+    DE_2030: 0.00
+    BI_2035: 0.026
+    GH_2035: 0.133
+    DE_2035: 0.00
+    BI_2040: 0.063
+    GH_2040: 0.266
+    DE_2040: 0.00
+    BI_2045: 0.113
+    GH_2045: 0.410
+    DE_2045: 0.021
+    BI_2050: 0.210
+    GH_2050: 0.584
+    DE_2050: 0.056
+
+  land_transport_electric_share: # 1 means all EVs  # This leads to problems when non-zero HERE
+    BI_2030: 0.022
+    GH_2030: 0.018
+    DE_2030: 0.038
+    BI_2035: 0.067
+    GH_2035: 0.054
+    DE_2035: 0.133
+    BI_2040: 0.117
+    GH_2040: 0.090
+    DE_2040: 0.264
+    BI_2045: 0.190
+    GH_2045: 0.164
+    DE_2045: 0.457
+    BI_2050: 0.301
+    GH_2050: 0.263
+    DE_2050: 0.742
+
+  bio_transport_share: # 1 means all EVs  # This leads to problems when non-zero HERE
+    BI_2030: 0.261
+    GH_2030: 0.231
+    DE_2030: 0.235
+    BI_2035: 0.343
+    GH_2035: 0.237
+    DE_2035: 0.253
+    BI_2040: 0.414
+    GH_2040: 0.222
+    DE_2040: 0.254
+    BI_2045: 0.491
+    GH_2045: 0.213
+    DE_2045: 0.261
+    BI_2050: 0.433
+    GH_2050: 0.093
+    DE_2050: 0.123
+
+
+
+  co2_network: true
+  co2_sequestration_potential: 70 #MtCO2/a sequestration potential for Europe
+  co2_sequestration_cost: 10 #EUR/tCO2 for sequestration of CO2
+  hydrogen_underground_storage: false
+  shipping_hydrogen_liquefaction: false
+  shipping_average_efficiency: 0.575 #For conversion of fuel oil to propulsion in 2011
+
+  shipping_hydrogen_share: #1.0
+    BI_2030: 0.0
+    GH_2030: 0.0
+    DE_2030: 0.0
+    BI_2035: 0.014
+    GH_2035: 0.014
+    DE_2035: 0.014
+    BI_2040: 0.064
+    GH_2040: 0.064
+    DE_2040: 0.065
+    BI_2045: 0.128
+    GH_2045: 0.130
+    DE_2045: 0.131
+    BI_2050: 0.240
+    GH_2050: 0.248
+    DE_2050: 0.254
+
+  gadm_level: 1
+  marginal_cost_storage: 0
+  methanation: true
+  helmeth: true
+  dac: true
+  SMR: true
+  SMR CC: true
+  cc_fraction: 0.9
+  cc: true
+  space_heat_share: 0.6 # the share of space heating from all heating. Remainder goes to water heating.
+  airport_sizing_factor: 3
+
+  min_part_load_fischer_tropsch: 0.9
+
+  conventional_generation: # generator : carrier
+    OCGT: gas
+    #Gen_Test: oil # Just for testing purposes
+
+# snapshots are originally set in PyPSA-Earth/config.yaml but used again by PyPSA-Earth-Sec
+snapshots:
+  # arguments to pd.date_range
+  start: "2013-01-01"
+  end: "2014-01-01"
+  inclusive: "left" # end is not inclusive
+
+# atlite:
+#   cutout: ./cutouts/africa-2013-era5.nc
+
+build_osm_network:  # TODO: To Remove this once we merge pypsa-earth and pypsa-earth-sec
+  force_ac: true  # When true, it forces all components (lines and substation) to be AC-only. To be used if DC assets create problem.
+
+solving:
+  #tmpdir: "path/to/tmp"
+  options:
+    formulation: kirchhoff
+    clip_p_max_pu: 1.e-2
+    load_shedding: false
+    noisy_costs: true
+    skip_iterations: true
+    track_iterations: false
+    min_iterations: 4
+    max_iterations: 6
+
+  solver:
+    name: gurobi
+    threads: 25
+    method: 2 # barrier
+    crossover: 0
+    BarConvTol: 1.e-6
+    Seed: 123
+    AggFill: 0
+    PreDual: 0
+    GURO_PAR_BARDENSETHRESH: 200
+    #FeasibilityTol: 1.e-6
+
+  mem: 30000 #memory in MB; 20 GB enough for 50+B+I+H2; 100 GB for 181+B+I+H2
+
+plotting:
+  map:
+    boundaries: [-11, 30, 34, 71]
+    color_geomap:
+      ocean: white
+      land: whitesmoke
+  costs_max: 10
+  costs_threshold: 0.2
+  energy_max: 20000
+  energy_min: -20000
+  energy_threshold: 15
+  vre_techs:
+  - onwind
+  - offwind-ac
+  - offwind-dc
+  - solar
+  - ror
+  renewable_storage_techs:
+  - PHS
+  - hydro
+  conv_techs:
+  - OCGT
+  - CCGT
+  - Nuclear
+  - Coal
+  storage_techs:
+  - hydro+PHS
+  - battery
+  - H2
+  load_carriers:
+  - AC load
+  AC_carriers:
+  - AC line
+  - AC transformer
+  link_carriers:
+  - DC line
+  - Converter AC-DC
+  heat_links:
+  - heat pump
+  - resistive heater
+  - CHP heat
+  - CHP electric
+  - gas boiler
+  - central heat pump
+  - central resistive heater
+  - central CHP heat
+  - central CHP electric
+  - central gas boiler
+  heat_generators:
+  - gas boiler
+  - central gas boiler
+  - solar thermal collector
+  - central solar thermal collector
+  tech_colors:
+    SMR CC: "darkblue"
+    gas for industry CC: "brown"
+    process emissions CC: "gray"
+    CO2 pipeline: "gray"
+    onwind: "dodgerblue"
+    onwind2: "dodgerblue"
+    onwind3: "dodgerblue"
+    onwind4: "dodgerblue"
+    onshore wind: "#235ebc"
+    offwind: "#6895dd"
+    offshore wind: "#6895dd"
+    offwind-ac: "c"
+    offshore wind (AC): "#6895dd"
+    offwind-dc: "#74c6f2"
+    offshore wind (DC): "#74c6f2"
+    wave: '#004444'
+    hydro: '#3B5323'
+    hydro reservoir: '#3B5323'
+    ror: '#78AB46'
+    run of river: '#78AB46'
+    hydroelectricity: 'blue'
+    solar: "orange"
+    solar PV: "#f9d002"
+    solar thermal: coral
+    solar rooftop: '#ffef60'
+    OCGT: wheat
+    OCGT marginal: sandybrown
+    OCGT-heat: '#ee8340'
+    gas boiler: '#ee8340'
+    gas boilers: '#ee8340'
+    gas boiler marginal: '#ee8340'
+    gas-to-power/heat: 'brown'
+    gas: brown
+    natural gas: brown
+    SMR: '#4F4F2F'
+    oil: '#B5A642'
+    oil EOP: '#B5A642'
+    oil boiler: '#B5A677'
+    lines: k
+    transmission lines: k
+    H2: m
+    H2 electrolysis: m
+    H2 liquefaction: m
+    hydrogen storage: m
+    battery: slategray
+    battery storage: slategray
+    home battery: '#614700'
+    home battery storage: '#614700'
+    Nuclear: r
+    Nuclear marginal: r
+    nuclear: r
+    uranium: r
+    Coal: k
+    coal: k
+    industry coal emissions: '#444444'
+    Coal marginal: k
+    Lignite: grey
+    lignite: grey
+    Lignite marginal: grey
+    CCGT: '#ee8340'
+    CCGT marginal: '#ee8340'
+    heat pumps: '#76EE00'
+    heat pump: '#76EE00'
+    air heat pump: '#76EE00'
+    ground heat pump: '#40AA00'
+    power-to-heat: 'red'
+    resistive heater: pink
+    Sabatier: '#FF1493'
+    methanation: '#FF1493'
+    power-to-gas: 'purple'
+    power-to-liquid: 'darkgreen'
+    helmeth: '#7D0552'
+    DAC: 'deeppink'
+    co2 stored: '#123456'
+    CO2 sequestration: '#123456'
+    CC: k
+    co2: '#123456'
+    co2 vent: '#654321'
+    agriculture heat: '#D07A7A'
+    agriculture oil: '#1e1e1e'
+    agriculture machinery oil: '#1e1e1e'
+    agriculture machinery oil emissions: '#111111'
+    agriculture electricity: '#222222'
+    solid biomass for industry co2 from atmosphere: '#654321'
+    solid biomass for industry co2 to stored: '#654321'
+    solid biomass for industry CC: '#654321'
+    gas for industry co2 to atmosphere: '#654321'
+    gas emissions: '#654321'
+    gas for industry co2 to stored: '#654321'
+    Fischer-Tropsch: '#44DD33'
+    kerosene for aviation: '#44BB11'
+    naphtha for industry: '#44FF55'
+    land transport oil: '#44DD33'
+    rail transport oil: '#44DD33'
+    water tanks: '#BBBBBB'
+    hot water storage: '#BBBBBB'
+    hot water charging: '#BBBBBB'
+    hot water discharging: '#999999'
+    # CO2 pipeline: '#999999'
+    CHP: r
+    CHP heat: r
+    CHP electric: r
+    PHS: g
+    Ambient: k
+    Electric load: b
+    Heat load: r
+    heat: darkred
+    rural heat: '#880000'
+    central heat: '#b22222'
+    decentral heat: '#800000'
+    low-temperature heat for industry: '#991111'
+    process heat: '#FF3333'
+    heat demand: darkred
+    electric demand: k
+    Li ion: grey
+    district heating: '#CC4E5C'
+    retrofitting: purple
+    building retrofitting: purple
+    BEV charger: grey
+    V2G: grey
+    land transport EV: grey
+    electricity: k
+    gas for industry: '#333333'
+    solid biomass for industry: '#555555'
+    industry electricity: '#222222'
+    industry new electricity: '#222222'
+    process emissions to stored: '#444444'
+    process emissions to atmosphere: '#888888'
+    process emissions: '#222222'
+    oil emissions: '#666666'
+    industry oil emissions: '#666666'
+    land transport oil emissions: '#666666'
+    land transport fuel cell: '#AAAAAA'
+    biogas: '#800000'
+    solid biomass: '#DAA520'
+    today: '#D2691E'
+    shipping: '#6495ED'
+    shipping oil: "#6495ED"
+    shipping oil emissions: "#6495ED"
+    electricity distribution grid: 'y'
+    solid biomass transport: green
+    H2 for industry: "#222222"
+    H2 for shipping: "#6495ED"
+    biomass EOP: "green"
+    biomass: "green"
+    high-temp electrolysis: "magenta"
+    oil pipeline: "grey"
+    agriculture biomass: "green"
+    biomass to liquid: "green"
+    H2 pipeline: m

--- a/config.bright_low.yaml
+++ b/config.bright_low.yaml
@@ -43,7 +43,7 @@ policy_config:
     limit_SMR_dispatch: true # Limits the dispatch of SMR to the reference case
     re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
   renewables:
-      ratio_rooftop_to_utility_solar:  # insert value to activate, leave empty to disable
+    ratio_rooftop_to_utility_solar:    # insert value to activate, leave empty to disable
 
 clustering_options:
   alternative_clustering: true
@@ -79,7 +79,7 @@ export:
     unload_time: 24 # hours for 48h see Hampp2021
 
 custom_data:
-  renewables_enertile: [ "solar-rooftop", "onwind", "onwind_rest", "solar"]
+  renewables_enertile: ["solar-rooftop", "onwind", "onwind_rest", "solar"]
   renewables: ["solar-rooftop", "onwind", "onwind2", "onwind3", "onwind4", "solar"] # ['csp', 'rooftop-solar', 'solar']
   energy_totals: true
   elec_demand: true

--- a/config.bright_med.yaml
+++ b/config.bright_med.yaml
@@ -43,7 +43,7 @@ policy_config:
     limit_SMR_dispatch: true # Limits the dispatch of SMR to the reference case
     re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
   renewables:
-      ratio_rooftop_to_utility_solar:  # insert value to activate, leave empty to disable
+    ratio_rooftop_to_utility_solar:    # insert value to activate, leave empty to disable
 
 clustering_options:
   alternative_clustering: true

--- a/config.bright_med.yaml
+++ b/config.bright_med.yaml
@@ -1,0 +1,656 @@
+logging_level: INFO
+tutorial: false
+
+results_dir: results/
+summary_dir: results/
+costs_dir: data/ #TODO change to the equivalent of technology data
+
+run:
+  name: 241107_ir_sensitivity
+  name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
+  shared_cutouts: true  # set to true to share the default cutout(s) across runs
+                        # Note: value false requires build_cutout to be enabled
+
+foresight: overnight
+
+# option to disable the subworkflow to ease the analyses
+disable_subworkflow: false
+
+scenario:
+  simpl: # only relevant for PyPSA-Eur
+  - ""
+  clusters: # number of nodes in Europe, any integer between 37 (1 node per country-zone) and several hundred
+  - 11
+  planning_horizons: # investment years for myopic and perfect; or costs year for overnight
+  - 2035
+  ll:
+  - "v1.0"
+  opts:
+  - "Co2L"
+  sopts:
+  - "3H"
+  demand: ["BI", "DE", "GH"] # BI/DE/GH
+
+policy_config:
+  hydrogen:
+    temporal_matching: "hour" #either "hour", "month", "year", "no_res_matching"
+    spatial_matching: false
+    additionality: true # RE electricity is equal to the amount required for additional hydrogen export compared to the 0 export case ("reference_case")
+    allowed_excess: 1.0
+    is_reference: false # Whether or not this network is a reference case network, relevant only if additionality is _true_
+    remove_h2_load: false #Whether or not to remove the h2 load from the network, relevant only if is_reference is _true_
+    path_to_ref: "/scratch/htc/cschauss/BRIGHT/submodules/pypsa-earth-sec/results/241107_ir_sensitivity/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.08_scenario_0export_endogenousmp.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
+    limit_SMR_dispatch: true # Limits the dispatch of SMR to the reference case
+    re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
+  renewables:
+      ratio_rooftop_to_utility_solar:  # insert value to activate, leave empty to disable
+
+clustering_options:
+  alternative_clustering: true
+
+countries: ['BR']
+
+demand_data:
+  update_data: true # if true, the workflow downloads the energy balances data saved in data/demand/unsd/data again. Turn on for the first run.
+  base_year: 2019
+
+  other_industries: false # Whether or not to include industries that are not specified. some countries have has exageratted numbers, check carefully.
+  aluminium_year: 2019 # Year of the aluminium demand data specified in `data/AL_production.csv`
+
+
+enable:
+  retrieve_cost_data: true # if true, the workflow overwrites the cost data saved in data/costs again
+
+fossil_reserves:
+  oil: 2000 #TWh Maybe reduntant
+
+
+export:
+  h2export: "endogenous" #,20,30,40,50,60,70,80,90,100] or "endogenous" in combination with h2mp # Yearly export demand in TWh
+  h2mp: [70, 72.5, 75, 77.5, 80, 82.5, 85, 87.5, 90] # Global hydrogen market price in EUR/MWh if h2export is set to endogenous
+  store: false # [True, False] # specifies wether an export store to balance demand is implemented
+  store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
+  export_profile: "constant" # use "ship" or "constant"
+  constant_nodal_export: true
+  ship:
+    ship_capacity: 0.4 # TWh # 0.05 TWh for new ones, 0.003 TWh for Susio Frontier, 0.4 TWh according to Hampp2021: "Corresponds to 11360 t H2 (l) with LHV of 33.3333 Mwh/t_H2. Cihlar et al 2020 based on IEA 2019, Table 3-B"
+    travel_time: 288 # hours # From Agadir to Rotterdam and back (12*24)
+    fill_time: 24 # hours, for 48h see Hampp2021
+    unload_time: 24 # hours for 48h see Hampp2021
+
+custom_data:
+  renewables_enertile: ["onwind", "onwind_rest", "solar", "solar-rooftop"]
+  renewables: ["onwind", "onwind2", "onwind3", "onwind4", "solar", "solar-rooftop"] # ['csp', 'rooftop-solar', 'solar']
+  energy_totals: true
+  elec_demand: true
+  heat_demand: false
+  industry_demand: true
+  industry_database: true
+  transport_demand: false
+  water_costs: false
+  h2_underground: false
+  add_existing: false
+  custom_sectors: false
+  gas_network: false # If "True" then a custom .csv file must be placed in "resources/custom_data/pipelines.csv" , If "False" the user can choose btw "greenfield" or Model built-in datasets. Please refer to ["sector"] below.
+  rename_industry_carriers: {"Electricity": "electricity", "Biofuels": "solid biomass", "Heat": "low-temperature heat", "Natural Gas": "gas", "Coal": "coal", "Hydrogen": "hydrogen", "Oil": "oil"}
+
+costs: # Costs used in PyPSA-Earth-Sec. Year depends on the wildcard planning_horizon in the scenario section
+  version: v0.9.2
+  lifetime: 25 #default lifetime
+  # From a Lion Hirth paper, also reflects average of Noothout et al 2016
+  discountrate: [0.08] #, 0.086, 0.111]
+  # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html # noqa: E501
+  USD2013_to_EUR2013: 0.7532
+
+  # Marginal and capital costs can be overwritten
+  # capital_cost:
+  #   onwind: 500
+  marginal_cost:
+    solar: 0.01
+    onwind: 0.015
+    offwind: 0.015
+    hydro: 0.
+    H2: 0.
+    battery: 0.
+
+  electrolyzer_cc: [0.5, 1]
+
+  emission_prices: # only used with the option Ep (emission prices)
+    co2: 0.
+
+  lines:
+    length_factor: 1.25 #to estimate offwind connection costs
+
+
+industry:
+  St_primary_fraction: 0.9 # fraction of steel produced via primary route versus secondary route (scrap+EAF); today fraction is 0.6
+    # 2020: 0.6
+    # 2025: 0.55
+    # 2030: 0.5
+    # 2035: 0.45
+    # 2040: 0.4
+    # 2045: 0.35
+    # 2050: 0.3
+  DRI_fraction: 0.5 # fraction of the primary route converted to DRI + EAF
+    # 2020: 0
+    # 2025: 0
+    # 2030: 0.05
+    # 2035: 0.2
+    # 2040: 0.4
+    # 2045: 0.7
+    # 2050: 1
+  H2_DRI: 1.7   #H2 consumption in Direct Reduced Iron (DRI),  MWh_H2,LHV/ton_Steel from 51kgH2/tSt in Vogl et al (2018) doi:10.1016/j.jclepro.2018.08.279
+  elec_DRI: 0.322   #electricity consumption in Direct Reduced Iron (DRI) shaft, MWh/tSt HYBRIT brochure https://ssabwebsitecdn.azureedge.net/-/media/hybrit/files/hybrit_brochure.pdf
+  Al_primary_fraction: 0.2 # fraction of aluminium produced via the primary route versus scrap; today fraction is 0.4
+    # 2020: 0.4
+    # 2025: 0.375
+    # 2030: 0.35
+    # 2035: 0.325
+    # 2040: 0.3
+    # 2045: 0.25
+    # 2050: 0.2
+  MWh_CH4_per_tNH3_SMR: 10.8 # 2012's demand from https://ec.europa.eu/docsroom/documents/4165/attachments/1/translations/en/renditions/pdf
+  MWh_elec_per_tNH3_SMR: 0.7 # same source, assuming 94-6% split methane-elec of total energy demand 11.5 MWh/tNH3
+  MWh_H2_per_tNH3_electrolysis: 6.5 # from https://doi.org/10.1016/j.joule.2018.04.017, around 0.197 tH2/tHN3 (>3/17 since some H2 lost and used for energy)
+  MWh_elec_per_tNH3_electrolysis: 1.17 # from https://doi.org/10.1016/j.joule.2018.04.017 Table 13 (air separation and HB)
+  NH3_process_emissions: 24.5 # in MtCO2/a from SMR for H2 production for NH3 from UNFCCC for 2015 for EU28
+  petrochemical_process_emissions: 25.5 # in MtCO2/a for petrochemical and other from UNFCCC for 2015 for EU28
+  HVC_primary_fraction: 1. # fraction of today's HVC produced via primary route
+  HVC_mechanical_recycling_fraction: 0. # fraction of today's HVC produced via mechanical recycling
+  HVC_chemical_recycling_fraction: 0. # fraction of today's HVC produced via chemical recycling
+  HVC_production_today: 52. # MtHVC/a from DECHEMA (2017), Figure 16, page 107; includes ethylene, propylene and BTX
+  MWh_elec_per_tHVC_mechanical_recycling: 0.547 # from SI of https://doi.org/10.1016/j.resconrec.2020.105010, Table S5, for HDPE, PP, PS, PET. LDPE would be 0.756.
+  MWh_elec_per_tHVC_chemical_recycling: 6.9 # Material Economics (2019), page 125; based on pyrolysis and electric steam cracking
+  chlorine_production_today: 9.58 # MtCl/a from DECHEMA (2017), Table 7, page 43
+  MWh_elec_per_tCl: 3.6 # DECHEMA (2017), Table 6, page 43
+  MWh_H2_per_tCl: -0.9372  # DECHEMA (2017), page 43; negative since hydrogen produced in chloralkali process
+  methanol_production_today: 1.5 # MtMeOH/a from DECHEMA (2017), page 62
+  MWh_elec_per_tMeOH: 0.167 # DECHEMA (2017), Table 14, page 65
+  MWh_CH4_per_tMeOH: 10.25 # DECHEMA (2017), Table 14, page 65
+  hotmaps_locate_missing: false
+  reference_year: 2015
+
+solar_thermal:
+  clearsky_model: simple
+  orientation:
+    slope: 45.
+    azimuth: 180.
+
+existing_capacities:
+  grouping_years_power: [1960, 1965, 1970, 1975, 1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025, 2030]
+  grouping_years_heat: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2019] # these should not extend 2020
+  threshold_capacity: 10
+  default_heating_lifetime: 20
+  conventional_carriers:
+  - lignite
+  - coal
+  - oil
+  - uranium
+
+sector:
+  gas:
+    spatial_gas: true # ALWAYS TRUE
+    network: false # ALWAYS FALSE for now (NOT USED)
+    network_data: GGIT # Global dataset -> 'GGIT' , European dataset -> 'IGGIELGN'
+    network_data_GGIT_status: ['Construction', 'Operating', 'Idle', 'Shelved', 'Mothballed', 'Proposed']
+  hydrogen:
+    network: true
+    network_limit: 25000 #GWkm
+    network_routes: greenfield # "gas or "greenfield". If "gas"  ->  the network data are fetched from ["sector"]["gas"]["network_data"]. If "greenfield"  -> the network follows the topology of electrical transmission lines
+    gas_network_repurposing: true # If true -> ["sector"]["gas"]["network"] is automatically false
+    underground_storage: false
+    hydrogen_colors: false
+    set_color_shares: false
+    blue_share: 0.40
+    pink_share: 0.05
+  coal:
+    shift_to_elec: true # If true, residential and services demand of coal is shifted to electricity. If false, the final energy demand of coal is disregarded
+  international_bunkers: false #Whether or not to count the emissions of international aviation and navigation
+
+  oil:
+    spatial_oil: true
+
+  district_heating:
+    potential: 0.3 #maximum fraction of urban demand which can be supplied by district heating
+      #increase of today's district heating demand to potential maximum district heating share
+      #progress = 0 means today's district heating share, progress=-1 means maxumzm fraction of urban demand is supplied by district heating
+    progress: 1
+      #2020: 0.0
+      #2030: 0.3
+      #2040: 0.6
+      #2050: 1.0
+    district_heating_loss: 0.15
+  reduce_space_heat_exogenously: true  # reduces space heat demand by a given factor (applied before losses in DH)
+  # this can represent e.g. building renovation, building demolition, or if
+  # the factor is negative: increasing floor area, increased thermal comfort, population growth
+  reduce_space_heat_exogenously_factor: 0.29 # per unit reduction in space heat demand
+  # the default factors are determined by the LTS scenario from http://tool.european-calculator.eu/app/buildings/building-types-area/?levers=1ddd4444421213bdbbbddd44444ffffff11f411111221111211l212221
+    # 2020: 0.10  # this results in a space heat demand reduction of 10%
+    # 2025: 0.09  # first heat demand increases compared to 2020 because of larger floor area per capita
+    # 2030: 0.09
+    # 2035: 0.11
+    # 2040: 0.16
+    # 2045: 0.21
+    # 2050: 0.29
+  tes: true
+  tes_tau: # 180 day time constant for centralised, 3 day for decentralised
+    decentral: 3
+    central: 180
+  boilers: true
+  oil_boilers: false
+  chp: true
+  micro_chp: false
+  solar_thermal: true
+  heat_pump_sink_T: 55 #Celsius, based on DTU / large area radiators; used un build_cop_profiles.py
+  time_dep_hp_cop: true #time dependent heat pump coefficient of performance
+  solar_cf_correction: 0.788457 # = >>>1/1.2683
+  bev_plug_to_wheel_efficiency: 0.2 #kWh/km from EPA https://www.fueleconomy.gov/feg/ for Tesla Model S
+  bev_charge_efficiency: 0.9 #BEV (dis-)charging efficiency
+  transport_heating_deadband_upper: 20.
+  transport_heating_deadband_lower: 15.
+  ICE_lower_degree_factor: 0.375 #in per cent increase in fuel consumption per degree above deadband
+  ICE_upper_degree_factor: 1.6
+  EV_lower_degree_factor: 0.98
+  EV_upper_degree_factor: 0.63
+  bev_avail_max: 0.95
+  bev_avail_mean: 0.8
+  bev_dsm_restriction_value: 0.75 #Set to 0 for no restriction on BEV DSM
+  bev_dsm_restriction_time: 7 #Time at which SOC of BEV has to be dsm_restriction_value
+  v2g: true #allows feed-in to grid from EV battery
+  bev_dsm: true #turns on EV battery
+  bev_energy: 0.05 #average battery size in MWh
+  bev_availability: 0.5 #How many cars do smart charging
+  transport_fuel_cell_efficiency: 1
+  transport_internal_combustion_efficiency: 1
+  industry_util_factor: 0.7
+
+  biomass_transport: true  # biomass transport between nodes
+  biomass_transport_default_cost: 0.1 #EUR/km/MWh
+  solid_biomass_potential: 3604 # 4805 TWh/a for all bioenergy sources according to Welfle (2017), 75% solid, 0.28% gaseous according to IEA (2021)
+  biogas_potential: 13.5 # TWh/a, Potential of whole modelled area
+  biomass_to_liquid: true
+
+  efficiency_heat_oil_to_elec: 0.9
+  efficiency_heat_biomass_to_elec: 0.9
+  efficiency_heat_gas_to_elec: 0.9
+
+  dynamic_transport:
+    enable: false # If "True", then the BEV and FCEV shares are obtained depening on the "Co2L"-wildcard (e.g. "Co2L0.70: 0.10"). If "False", then the shares are obtained depending on the "demand" wildcard and "planning_horizons" wildcard as listed below (e.g. "DF_2050: 0.08")
+    land_transport_electric_share:
+      Co2L2.0: 0.00
+      Co2L1.0: 0.01
+      Co2L0.90: 0.03
+      Co2L0.80: 0.06
+      Co2L0.70: 0.10
+      Co2L0.60: 0.17
+      Co2L0.50: 0.27
+      Co2L0.40: 0.40
+      Co2L0.30: 0.55
+      Co2L0.20: 0.69
+      Co2L0.10: 0.80
+      Co2L0.00: 0.88
+    land_transport_fuel_cell_share:
+      Co2L2.0: 0.01
+      Co2L1.0: 0.01
+      Co2L0.90: 0.01
+      Co2L0.80: 0.01
+      Co2L0.70: 0.01
+      Co2L0.60: 0.01
+      Co2L0.50: 0.01
+      Co2L0.40: 0.01
+      Co2L0.30: 0.01
+      Co2L0.20: 0.01
+      Co2L0.10: 0.01
+      Co2L0.00: 0.01
+    bio_transport_share:
+      Co2L2.0: 0.01
+      Co2L1.0: 0.01
+      Co2L0.90: 0.01
+      Co2L0.80: 0.01
+      Co2L0.70: 0.01
+      Co2L0.60: 0.01
+      Co2L0.50: 0.01
+      Co2L0.40: 0.01
+      Co2L0.30: 0.01
+      Co2L0.20: 0.01
+      Co2L0.10: 0.01
+      Co2L0.00: 0.01
+
+  land_transport_fuel_cell_share: # 1 means all FCEVs HERE
+    BI_2030: 0.007
+    GH_2030: 0.036
+    DE_2030: 0.00
+    BI_2035: 0.026
+    GH_2035: 0.133
+    DE_2035: 0.00
+    BI_2040: 0.063
+    GH_2040: 0.266
+    DE_2040: 0.00
+    BI_2045: 0.113
+    GH_2045: 0.410
+    DE_2045: 0.021
+    BI_2050: 0.210
+    GH_2050: 0.584
+    DE_2050: 0.056
+
+  land_transport_electric_share: # 1 means all EVs  # This leads to problems when non-zero HERE
+    BI_2030: 0.022
+    GH_2030: 0.018
+    DE_2030: 0.038
+    BI_2035: 0.067
+    GH_2035: 0.054
+    DE_2035: 0.133
+    BI_2040: 0.117
+    GH_2040: 0.090
+    DE_2040: 0.264
+    BI_2045: 0.190
+    GH_2045: 0.164
+    DE_2045: 0.457
+    BI_2050: 0.301
+    GH_2050: 0.263
+    DE_2050: 0.742
+
+  bio_transport_share: # 1 means all EVs  # This leads to problems when non-zero HERE
+    BI_2030: 0.261
+    GH_2030: 0.231
+    DE_2030: 0.235
+    BI_2035: 0.343
+    GH_2035: 0.237
+    DE_2035: 0.253
+    BI_2040: 0.414
+    GH_2040: 0.222
+    DE_2040: 0.254
+    BI_2045: 0.491
+    GH_2045: 0.213
+    DE_2045: 0.261
+    BI_2050: 0.433
+    GH_2050: 0.093
+    DE_2050: 0.123
+
+
+
+  co2_network: true
+  co2_sequestration_potential: 70 #MtCO2/a sequestration potential for Europe
+  co2_sequestration_cost: 10 #EUR/tCO2 for sequestration of CO2
+  hydrogen_underground_storage: false
+  shipping_hydrogen_liquefaction: false
+  shipping_average_efficiency: 0.575 #For conversion of fuel oil to propulsion in 2011
+
+  shipping_hydrogen_share: #1.0
+    BI_2030: 0.0
+    GH_2030: 0.0
+    DE_2030: 0.0
+    BI_2035: 0.014
+    GH_2035: 0.014
+    DE_2035: 0.014
+    BI_2040: 0.064
+    GH_2040: 0.064
+    DE_2040: 0.065
+    BI_2045: 0.128
+    GH_2045: 0.130
+    DE_2045: 0.131
+    BI_2050: 0.240
+    GH_2050: 0.248
+    DE_2050: 0.254
+
+  gadm_level: 1
+  marginal_cost_storage: 0
+  methanation: true
+  helmeth: true
+  dac: true
+  SMR: true
+  SMR CC: true
+  cc_fraction: 0.9
+  cc: true
+  space_heat_share: 0.6 # the share of space heating from all heating. Remainder goes to water heating.
+  airport_sizing_factor: 3
+
+  min_part_load_fischer_tropsch: 0.9
+
+  conventional_generation: # generator : carrier
+    OCGT: gas
+    #Gen_Test: oil # Just for testing purposes
+
+# snapshots are originally set in PyPSA-Earth/config.yaml but used again by PyPSA-Earth-Sec
+snapshots:
+  # arguments to pd.date_range
+  start: "2013-01-01"
+  end: "2014-01-01"
+  inclusive: "left" # end is not inclusive
+
+# atlite:
+#   cutout: ./cutouts/africa-2013-era5.nc
+
+build_osm_network:  # TODO: To Remove this once we merge pypsa-earth and pypsa-earth-sec
+  force_ac: true  # When true, it forces all components (lines and substation) to be AC-only. To be used if DC assets create problem.
+
+solving:
+  #tmpdir: "path/to/tmp"
+  options:
+    formulation: kirchhoff
+    clip_p_max_pu: 1.e-2
+    load_shedding: false
+    noisy_costs: true
+    skip_iterations: true
+    track_iterations: false
+    min_iterations: 4
+    max_iterations: 6
+
+  solver:
+    name: gurobi
+    threads: 25
+    method: 2 # barrier
+    crossover: 0
+    BarConvTol: 1.e-6
+    Seed: 123
+    AggFill: 0
+    PreDual: 0
+    GURO_PAR_BARDENSETHRESH: 200
+    #FeasibilityTol: 1.e-6
+
+  mem: 30000 #memory in MB; 20 GB enough for 50+B+I+H2; 100 GB for 181+B+I+H2
+
+plotting:
+  map:
+    boundaries: [-11, 30, 34, 71]
+    color_geomap:
+      ocean: white
+      land: whitesmoke
+  costs_max: 10
+  costs_threshold: 0.2
+  energy_max: 20000
+  energy_min: -20000
+  energy_threshold: 15
+  vre_techs:
+  - onwind
+  - offwind-ac
+  - offwind-dc
+  - solar
+  - ror
+  renewable_storage_techs:
+  - PHS
+  - hydro
+  conv_techs:
+  - OCGT
+  - CCGT
+  - Nuclear
+  - Coal
+  storage_techs:
+  - hydro+PHS
+  - battery
+  - H2
+  load_carriers:
+  - AC load
+  AC_carriers:
+  - AC line
+  - AC transformer
+  link_carriers:
+  - DC line
+  - Converter AC-DC
+  heat_links:
+  - heat pump
+  - resistive heater
+  - CHP heat
+  - CHP electric
+  - gas boiler
+  - central heat pump
+  - central resistive heater
+  - central CHP heat
+  - central CHP electric
+  - central gas boiler
+  heat_generators:
+  - gas boiler
+  - central gas boiler
+  - solar thermal collector
+  - central solar thermal collector
+  tech_colors:
+    SMR CC: "darkblue"
+    gas for industry CC: "brown"
+    process emissions CC: "gray"
+    CO2 pipeline: "gray"
+    onwind: "dodgerblue"
+    onwind2: "dodgerblue"
+    onwind3: "dodgerblue"
+    onwind4: "dodgerblue"
+    onshore wind: "#235ebc"
+    offwind: "#6895dd"
+    offshore wind: "#6895dd"
+    offwind-ac: "c"
+    offshore wind (AC): "#6895dd"
+    offwind-dc: "#74c6f2"
+    offshore wind (DC): "#74c6f2"
+    wave: '#004444'
+    hydro: '#3B5323'
+    hydro reservoir: '#3B5323'
+    ror: '#78AB46'
+    run of river: '#78AB46'
+    hydroelectricity: 'blue'
+    solar: "orange"
+    solar PV: "#f9d002"
+    solar thermal: coral
+    solar rooftop: '#ffef60'
+    OCGT: wheat
+    OCGT marginal: sandybrown
+    OCGT-heat: '#ee8340'
+    gas boiler: '#ee8340'
+    gas boilers: '#ee8340'
+    gas boiler marginal: '#ee8340'
+    gas-to-power/heat: 'brown'
+    gas: brown
+    natural gas: brown
+    SMR: '#4F4F2F'
+    oil: '#B5A642'
+    oil EOP: '#B5A642'
+    oil boiler: '#B5A677'
+    lines: k
+    transmission lines: k
+    H2: m
+    H2 electrolysis: m
+    H2 liquefaction: m
+    hydrogen storage: m
+    battery: slategray
+    battery storage: slategray
+    home battery: '#614700'
+    home battery storage: '#614700'
+    Nuclear: r
+    Nuclear marginal: r
+    nuclear: r
+    uranium: r
+    Coal: k
+    coal: k
+    industry coal emissions: '#444444'
+    Coal marginal: k
+    Lignite: grey
+    lignite: grey
+    Lignite marginal: grey
+    CCGT: '#ee8340'
+    CCGT marginal: '#ee8340'
+    heat pumps: '#76EE00'
+    heat pump: '#76EE00'
+    air heat pump: '#76EE00'
+    ground heat pump: '#40AA00'
+    power-to-heat: 'red'
+    resistive heater: pink
+    Sabatier: '#FF1493'
+    methanation: '#FF1493'
+    power-to-gas: 'purple'
+    power-to-liquid: 'darkgreen'
+    helmeth: '#7D0552'
+    DAC: 'deeppink'
+    co2 stored: '#123456'
+    CO2 sequestration: '#123456'
+    CC: k
+    co2: '#123456'
+    co2 vent: '#654321'
+    agriculture heat: '#D07A7A'
+    agriculture oil: '#1e1e1e'
+    agriculture machinery oil: '#1e1e1e'
+    agriculture machinery oil emissions: '#111111'
+    agriculture electricity: '#222222'
+    solid biomass for industry co2 from atmosphere: '#654321'
+    solid biomass for industry co2 to stored: '#654321'
+    solid biomass for industry CC: '#654321'
+    gas for industry co2 to atmosphere: '#654321'
+    gas emissions: '#654321'
+    gas for industry co2 to stored: '#654321'
+    Fischer-Tropsch: '#44DD33'
+    kerosene for aviation: '#44BB11'
+    naphtha for industry: '#44FF55'
+    land transport oil: '#44DD33'
+    rail transport oil: '#44DD33'
+    water tanks: '#BBBBBB'
+    hot water storage: '#BBBBBB'
+    hot water charging: '#BBBBBB'
+    hot water discharging: '#999999'
+    # CO2 pipeline: '#999999'
+    CHP: r
+    CHP heat: r
+    CHP electric: r
+    PHS: g
+    Ambient: k
+    Electric load: b
+    Heat load: r
+    heat: darkred
+    rural heat: '#880000'
+    central heat: '#b22222'
+    decentral heat: '#800000'
+    low-temperature heat for industry: '#991111'
+    process heat: '#FF3333'
+    heat demand: darkred
+    electric demand: k
+    Li ion: grey
+    district heating: '#CC4E5C'
+    retrofitting: purple
+    building retrofitting: purple
+    BEV charger: grey
+    V2G: grey
+    land transport EV: grey
+    electricity: k
+    gas for industry: '#333333'
+    solid biomass for industry: '#555555'
+    industry electricity: '#222222'
+    industry new electricity: '#222222'
+    process emissions to stored: '#444444'
+    process emissions to atmosphere: '#888888'
+    process emissions: '#222222'
+    oil emissions: '#666666'
+    industry oil emissions: '#666666'
+    land transport oil emissions: '#666666'
+    land transport fuel cell: '#AAAAAA'
+    biogas: '#800000'
+    solid biomass: '#DAA520'
+    today: '#D2691E'
+    shipping: '#6495ED'
+    shipping oil: "#6495ED"
+    shipping oil emissions: "#6495ED"
+    electricity distribution grid: 'y'
+    solid biomass transport: green
+    H2 for industry: "#222222"
+    H2 for shipping: "#6495ED"
+    biomass EOP: "green"
+    biomass: "green"
+    high-temp electrolysis: "magenta"
+    oil pipeline: "grey"
+    agriculture biomass: "green"
+    biomass to liquid: "green"
+    H2 pipeline: m

--- a/config.bright_ref_high.yaml
+++ b/config.bright_ref_high.yaml
@@ -1,0 +1,659 @@
+logging_level: INFO
+tutorial: false
+
+results_dir: results/
+summary_dir: results/
+costs_dir: data/ #TODO change to the equivalent of technology data
+
+run:
+  name: 241107_ir_sensitivity
+  name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
+  shared_cutouts: true  # set to true to share the default cutout(s) across runs
+                        # Note: value false requires build_cutout to be enabled
+
+foresight: overnight
+
+# option to disable the subworkflow to ease the analyses
+disable_subworkflow: false
+
+scenario:
+  simpl: # only relevant for PyPSA-Eur
+  - ""
+  clusters: # number of nodes in Europe, any integer between 37 (1 node per country-zone) and several hundred
+  - 11
+  planning_horizons: # investment years for myopic and perfect; or costs year for overnight
+  - 2035
+  ll:
+  - "v1.0"
+  opts:
+  - "Co2L"
+  sopts:
+  - "3H"
+  demand: ["BI", "DE", "GH"] # BI/DE/GH
+
+policy_config:
+  hydrogen:
+    temporal_matching: "hour" #either "hour", "month", "year", "no_res_matching"
+    spatial_matching: false
+    additionality: true # RE electricity is equal to the amount required for additional hydrogen export compared to the 0 export case ("reference_case")
+    allowed_excess: 1.0
+    is_reference: true # Whether or not this network is a reference case network, relevant only if additionality is _true_
+    remove_h2_load: false #Whether or not to remove the h2 load from the network, relevant only if is_reference is _true_
+    path_to_ref: "" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
+    limit_SMR_dispatch: true # Limits the dispatch of SMR to the reference case
+  renewables:
+    ratio_rooftop_to_utility_solar: 2 # insert value to activate, leave empty to disable
+
+    re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
+
+clustering_options:
+  alternative_clustering: true
+
+countries: ['BR']
+
+demand_data:
+  update_data: true # if true, the workflow downloads the energy balances data saved in data/demand/unsd/data again. Turn on for the first run.
+  base_year: 2019
+
+  other_industries: false # Whether or not to include industries that are not specified. some countries have has exageratted numbers, check carefully.
+  aluminium_year: 2019 # Year of the aluminium demand data specified in `data/AL_production.csv`
+
+
+enable:
+  retrieve_cost_data: true # if true, the workflow overwrites the cost data saved in data/costs again
+
+fossil_reserves:
+  oil: 2000 #TWh Maybe reduntant
+
+
+export:
+  h2export: [0] #,20,30,40,50,60,70,80,90,100] or "endogenous" in combination with h2mp # Yearly export demand in TWh
+  h2mp: "endogenous" # Global hydrogen market price in EUR/MWh if h2export is set to endogenous else "endogenous"
+  store: false # [True, False] # specifies wether an export store to balance demand is implemented
+  store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
+  export_profile: "constant" # use "ship" or "constant"
+  constant_nodal_export: true
+  ship:
+    ship_capacity: 0.4 # TWh # 0.05 TWh for new ones, 0.003 TWh for Susio Frontier, 0.4 TWh according to Hampp2021: "Corresponds to 11360 t H2 (l) with LHV of 33.3333 Mwh/t_H2. Cihlar et al 2020 based on IEA 2019, Table 3-B"
+    travel_time: 288 # hours # From Agadir to Rotterdam and back (12*24)
+    fill_time: 24 # hours, for 48h see Hampp2021
+    unload_time: 24 # hours for 48h see Hampp2021
+
+custom_data:
+  renewables_enertile: ["onwind", "onwind_rest", "solar", "solar-rooftop"]
+  renewables: ["onwind", "onwind2", "onwind3", "onwind4", "solar", "solar-rooftop"] # ['csp', 'rooftop-solar', 'solar']
+  energy_totals: true
+  elec_demand: true
+  heat_demand: false
+  industry_demand: true
+  industry_database: true
+  transport_demand: false
+  water_costs: false
+  h2_underground: false
+  add_existing: false
+  custom_sectors: false
+  gas_network: false # If "True" then a custom .csv file must be placed in "resources/custom_data/pipelines.csv" , If "False" the user can choose btw "greenfield" or Model built-in datasets. Please refer to ["sector"] below.
+  rename_industry_carriers: {"Electricity": "electricity", "Biofuels": "solid biomass", "Heat": "low-temperature heat", "Natural Gas": "gas", "Coal": "coal", "Hydrogen": "hydrogen", "Oil": "oil"}
+
+costs: # Costs used in PyPSA-Earth-Sec. Year depends on the wildcard planning_horizon in the scenario section
+  version: v0.9.2
+  lifetime: 25 #default lifetime
+  # From a Lion Hirth paper, also reflects average of Noothout et al 2016
+  discountrate: [0.1] #, 0.086, 0.111]
+  # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html # noqa: E501
+  USD2013_to_EUR2013: 0.7532
+
+  # Marginal and capital costs can be overwritten
+  # capital_cost:
+  #   onwind: 500
+  marginal_cost:
+    solar: 0.01
+    onwind: 0.015
+    offwind: 0.015
+    hydro: 0.
+    H2: 0.
+    battery: 0.
+
+  electrolyzer_cc: [0.5,1]
+
+  emission_prices: # only used with the option Ep (emission prices)
+    co2: 0.
+
+  lines:
+    length_factor: 1.25 #to estimate offwind connection costs
+
+
+industry:
+  St_primary_fraction: 0.9 # fraction of steel produced via primary route versus secondary route (scrap+EAF); today fraction is 0.6
+    # 2020: 0.6
+    # 2025: 0.55
+    # 2030: 0.5
+    # 2035: 0.45
+    # 2040: 0.4
+    # 2045: 0.35
+    # 2050: 0.3
+  DRI_fraction: 0.5 # fraction of the primary route converted to DRI + EAF
+    # 2020: 0
+    # 2025: 0
+    # 2030: 0.05
+    # 2035: 0.2
+    # 2040: 0.4
+    # 2045: 0.7
+    # 2050: 1
+  H2_DRI: 1.7   #H2 consumption in Direct Reduced Iron (DRI),  MWh_H2,LHV/ton_Steel from 51kgH2/tSt in Vogl et al (2018) doi:10.1016/j.jclepro.2018.08.279
+  elec_DRI: 0.322   #electricity consumption in Direct Reduced Iron (DRI) shaft, MWh/tSt HYBRIT brochure https://ssabwebsitecdn.azureedge.net/-/media/hybrit/files/hybrit_brochure.pdf
+  Al_primary_fraction: 0.2 # fraction of aluminium produced via the primary route versus scrap; today fraction is 0.4
+    # 2020: 0.4
+    # 2025: 0.375
+    # 2030: 0.35
+    # 2035: 0.325
+    # 2040: 0.3
+    # 2045: 0.25
+    # 2050: 0.2
+  MWh_CH4_per_tNH3_SMR: 10.8 # 2012's demand from https://ec.europa.eu/docsroom/documents/4165/attachments/1/translations/en/renditions/pdf
+  MWh_elec_per_tNH3_SMR: 0.7 # same source, assuming 94-6% split methane-elec of total energy demand 11.5 MWh/tNH3
+  MWh_H2_per_tNH3_electrolysis: 6.5 # from https://doi.org/10.1016/j.joule.2018.04.017, around 0.197 tH2/tHN3 (>3/17 since some H2 lost and used for energy)
+  MWh_elec_per_tNH3_electrolysis: 1.17 # from https://doi.org/10.1016/j.joule.2018.04.017 Table 13 (air separation and HB)
+  NH3_process_emissions: 24.5 # in MtCO2/a from SMR for H2 production for NH3 from UNFCCC for 2015 for EU28
+  petrochemical_process_emissions: 25.5 # in MtCO2/a for petrochemical and other from UNFCCC for 2015 for EU28
+  HVC_primary_fraction: 1. # fraction of today's HVC produced via primary route
+  HVC_mechanical_recycling_fraction: 0. # fraction of today's HVC produced via mechanical recycling
+  HVC_chemical_recycling_fraction: 0. # fraction of today's HVC produced via chemical recycling
+  HVC_production_today: 52. # MtHVC/a from DECHEMA (2017), Figure 16, page 107; includes ethylene, propylene and BTX
+  MWh_elec_per_tHVC_mechanical_recycling: 0.547 # from SI of https://doi.org/10.1016/j.resconrec.2020.105010, Table S5, for HDPE, PP, PS, PET. LDPE would be 0.756.
+  MWh_elec_per_tHVC_chemical_recycling: 6.9 # Material Economics (2019), page 125; based on pyrolysis and electric steam cracking
+  chlorine_production_today: 9.58 # MtCl/a from DECHEMA (2017), Table 7, page 43
+  MWh_elec_per_tCl: 3.6 # DECHEMA (2017), Table 6, page 43
+  MWh_H2_per_tCl: -0.9372  # DECHEMA (2017), page 43; negative since hydrogen produced in chloralkali process
+  methanol_production_today: 1.5 # MtMeOH/a from DECHEMA (2017), page 62
+  MWh_elec_per_tMeOH: 0.167 # DECHEMA (2017), Table 14, page 65
+  MWh_CH4_per_tMeOH: 10.25 # DECHEMA (2017), Table 14, page 65
+  hotmaps_locate_missing: false
+  reference_year: 2015
+
+solar_thermal:
+  clearsky_model: simple
+  orientation:
+    slope: 45.
+    azimuth: 180.
+
+existing_capacities:
+  grouping_years_power: [1960, 1965, 1970, 1975, 1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025, 2030]
+  grouping_years_heat: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2019] # these should not extend 2020
+  threshold_capacity: 10
+  default_heating_lifetime: 20
+  conventional_carriers:
+  - lignite
+  - coal
+  - oil
+  - uranium
+
+sector:
+  gas:
+    spatial_gas: true # ALWAYS TRUE
+    network: false # ALWAYS FALSE for now (NOT USED)
+    network_data: GGIT # Global dataset -> 'GGIT' , European dataset -> 'IGGIELGN'
+    network_data_GGIT_status: ['Construction', 'Operating', 'Idle', 'Shelved', 'Mothballed', 'Proposed']
+  hydrogen:
+    network: true
+    network_limit: 25000 #GWkm
+    network_routes: greenfield # "gas or "greenfield". If "gas"  ->  the network data are fetched from ["sector"]["gas"]["network_data"]. If "greenfield"  -> the network follows the topology of electrical transmission lines
+    gas_network_repurposing: true # If true -> ["sector"]["gas"]["network"] is automatically false
+    underground_storage: false
+    hydrogen_colors: false
+    set_color_shares: false
+    blue_share: 0.40
+    pink_share: 0.05
+  coal:
+    shift_to_elec: true # If true, residential and services demand of coal is shifted to electricity. If false, the final energy demand of coal is disregarded
+  international_bunkers: false #Whether or not to count the emissions of international aviation and navigation
+
+  oil:
+    spatial_oil: true
+
+  district_heating:
+    potential: 0.3 #maximum fraction of urban demand which can be supplied by district heating
+      #increase of today's district heating demand to potential maximum district heating share
+      #progress = 0 means today's district heating share, progress=-1 means maxumzm fraction of urban demand is supplied by district heating
+    progress: 1
+      #2020: 0.0
+      #2030: 0.3
+      #2040: 0.6
+      #2050: 1.0
+    district_heating_loss: 0.15
+  reduce_space_heat_exogenously: true  # reduces space heat demand by a given factor (applied before losses in DH)
+  # this can represent e.g. building renovation, building demolition, or if
+  # the factor is negative: increasing floor area, increased thermal comfort, population growth
+  reduce_space_heat_exogenously_factor: 0.29 # per unit reduction in space heat demand
+  # the default factors are determined by the LTS scenario from http://tool.european-calculator.eu/app/buildings/building-types-area/?levers=1ddd4444421213bdbbbddd44444ffffff11f411111221111211l212221
+    # 2020: 0.10  # this results in a space heat demand reduction of 10%
+    # 2025: 0.09  # first heat demand increases compared to 2020 because of larger floor area per capita
+    # 2030: 0.09
+    # 2035: 0.11
+    # 2040: 0.16
+    # 2045: 0.21
+    # 2050: 0.29
+  tes: true
+  tes_tau: # 180 day time constant for centralised, 3 day for decentralised
+    decentral: 3
+    central: 180
+  boilers: true
+  oil_boilers: false
+  chp: true
+  micro_chp: false
+  solar_thermal: true
+  heat_pump_sink_T: 55 #Celsius, based on DTU / large area radiators; used un build_cop_profiles.py
+  time_dep_hp_cop: true #time dependent heat pump coefficient of performance
+  solar_cf_correction: 0.788457 # = >>>1/1.2683
+  bev_plug_to_wheel_efficiency: 0.2 #kWh/km from EPA https://www.fueleconomy.gov/feg/ for Tesla Model S
+  bev_charge_efficiency: 0.9 #BEV (dis-)charging efficiency
+  transport_heating_deadband_upper: 20.
+  transport_heating_deadband_lower: 15.
+  ICE_lower_degree_factor: 0.375 #in per cent increase in fuel consumption per degree above deadband
+  ICE_upper_degree_factor: 1.6
+  EV_lower_degree_factor: 0.98
+  EV_upper_degree_factor: 0.63
+  bev_avail_max: 0.95
+  bev_avail_mean: 0.8
+  bev_dsm_restriction_value: 0.75 #Set to 0 for no restriction on BEV DSM
+  bev_dsm_restriction_time: 7 #Time at which SOC of BEV has to be dsm_restriction_value
+  v2g: true #allows feed-in to grid from EV battery
+  bev_dsm: true #turns on EV battery
+  bev_energy: 0.05 #average battery size in MWh
+  bev_availability: 0.5 #How many cars do smart charging
+  transport_fuel_cell_efficiency: 1
+  transport_internal_combustion_efficiency: 1
+  industry_util_factor: 0.7
+
+  biomass_transport: true  # biomass transport between nodes
+  biomass_transport_default_cost: 0.1 #EUR/km/MWh
+  solid_biomass_potential: 3604 # 4805 TWh/a for all bioenergy sources according to Welfle (2017), 75% solid, 0.28% gaseous according to IEA (2021)
+  biogas_potential: 13.5 # TWh/a, Potential of whole modelled area
+  biomass_to_liquid: true
+
+  efficiency_heat_oil_to_elec: 0.9
+  efficiency_heat_biomass_to_elec: 0.9
+  efficiency_heat_gas_to_elec: 0.9
+
+  dynamic_transport:
+    enable: false # If "True", then the BEV and FCEV shares are obtained depening on the "Co2L"-wildcard (e.g. "Co2L0.70: 0.10"). If "False", then the shares are obtained depending on the "demand" wildcard and "planning_horizons" wildcard as listed below (e.g. "DF_2050: 0.08")
+    land_transport_electric_share:
+      Co2L2.0: 0.00
+      Co2L1.0: 0.01
+      Co2L0.90: 0.03
+      Co2L0.80: 0.06
+      Co2L0.70: 0.10
+      Co2L0.60: 0.17
+      Co2L0.50: 0.27
+      Co2L0.40: 0.40
+      Co2L0.30: 0.55
+      Co2L0.20: 0.69
+      Co2L0.10: 0.80
+      Co2L0.00: 0.88
+    land_transport_fuel_cell_share:
+      Co2L2.0: 0.01
+      Co2L1.0: 0.01
+      Co2L0.90: 0.01
+      Co2L0.80: 0.01
+      Co2L0.70: 0.01
+      Co2L0.60: 0.01
+      Co2L0.50: 0.01
+      Co2L0.40: 0.01
+      Co2L0.30: 0.01
+      Co2L0.20: 0.01
+      Co2L0.10: 0.01
+      Co2L0.00: 0.01
+    bio_transport_share:
+      Co2L2.0: 0.01
+      Co2L1.0: 0.01
+      Co2L0.90: 0.01
+      Co2L0.80: 0.01
+      Co2L0.70: 0.01
+      Co2L0.60: 0.01
+      Co2L0.50: 0.01
+      Co2L0.40: 0.01
+      Co2L0.30: 0.01
+      Co2L0.20: 0.01
+      Co2L0.10: 0.01
+      Co2L0.00: 0.01
+
+  land_transport_fuel_cell_share: # 1 means all FCEVs HERE
+    BI_2030: 0.007
+    GH_2030: 0.036
+    DE_2030: 0.00
+    BI_2035: 0.026
+    GH_2035: 0.133
+    DE_2035: 0.00
+    BI_2040: 0.063
+    GH_2040: 0.266
+    DE_2040: 0.00
+    BI_2045: 0.113
+    GH_2045: 0.410
+    DE_2045: 0.021
+    BI_2050: 0.210
+    GH_2050: 0.584
+    DE_2050: 0.056
+
+  land_transport_electric_share: # 1 means all EVs  # This leads to problems when non-zero HERE
+    BI_2030: 0.022
+    GH_2030: 0.018
+    DE_2030: 0.038
+    BI_2035: 0.067
+    GH_2035: 0.054
+    DE_2035: 0.133
+    BI_2040: 0.117
+    GH_2040: 0.090
+    DE_2040: 0.264
+    BI_2045: 0.190
+    GH_2045: 0.164
+    DE_2045: 0.457
+    BI_2050: 0.301
+    GH_2050: 0.263
+    DE_2050: 0.742
+
+  bio_transport_share: # 1 means all EVs  # This leads to problems when non-zero HERE
+    BI_2030: 0.261
+    GH_2030: 0.231
+    DE_2030: 0.235
+    BI_2035: 0.343
+    GH_2035: 0.237
+    DE_2035: 0.253
+    BI_2040: 0.414
+    GH_2040: 0.222
+    DE_2040: 0.254
+    BI_2045: 0.491
+    GH_2045: 0.213
+    DE_2045: 0.261
+    BI_2050: 0.433
+    GH_2050: 0.093
+    DE_2050: 0.123
+
+
+
+  co2_network: true
+  co2_sequestration_potential: 70 #MtCO2/a sequestration potential for Europe
+  co2_sequestration_cost: 10 #EUR/tCO2 for sequestration of CO2
+  hydrogen_underground_storage: false
+  shipping_hydrogen_liquefaction: false
+  shipping_average_efficiency: 0.575 #For conversion of fuel oil to propulsion in 2011
+
+  shipping_hydrogen_share: #1.0
+    BU_2030: 0.00
+    BI_2030: 0.00
+    BI_2035: 0.014
+    GH_2030: 0.00
+    GH_2035: 0.014
+    DE_2030: 0.00
+    DE_2035: 0.014
+    AP_2030: 0.00
+    NZ_2030: 0.10
+    DF_2030: 0.05
+    AB_2030: 0.05
+    BU_2050: 0.00
+    BI_2050: 0.24
+    GH_2050: 0.248
+    DE_2050: 0.254
+    AP_2050: 0.25
+    NZ_2050: 0.36
+    DF_2050: 0.12
+
+  gadm_level: 1
+  marginal_cost_storage: 0
+  methanation: true
+  helmeth: true
+  dac: true
+  SMR: true
+  SMR CC: true
+  cc_fraction: 0.9
+  cc: true
+  space_heat_share: 0.6 # the share of space heating from all heating. Remainder goes to water heating.
+  airport_sizing_factor: 3
+
+  min_part_load_fischer_tropsch: 0.9
+
+  conventional_generation: # generator : carrier
+    OCGT: gas
+    #Gen_Test: oil # Just for testing purposes
+
+# snapshots are originally set in PyPSA-Earth/config.yaml but used again by PyPSA-Earth-Sec
+snapshots:
+  # arguments to pd.date_range
+  start: "2013-01-01"
+  end: "2014-01-01"
+  inclusive: "left" # end is not inclusive
+
+# atlite:
+#   cutout: ./cutouts/africa-2013-era5.nc
+
+build_osm_network:  # TODO: To Remove this once we merge pypsa-earth and pypsa-earth-sec
+  force_ac: true  # When true, it forces all components (lines and substation) to be AC-only. To be used if DC assets create problem.
+
+solving:
+  #tmpdir: "path/to/tmp"
+  options:
+    formulation: kirchhoff
+    clip_p_max_pu: 1.e-2
+    load_shedding: false
+    noisy_costs: true
+    skip_iterations: true
+    track_iterations: false
+    min_iterations: 4
+    max_iterations: 6
+
+  solver:
+    name: gurobi
+    threads: 25
+    method: 2 # barrier
+    crossover: 0
+    BarConvTol: 1.e-6
+    Seed: 123
+    AggFill: 0
+    PreDual: 0
+    GURO_PAR_BARDENSETHRESH: 200
+    #FeasibilityTol: 1.e-6
+
+  mem: 30000 #memory in MB; 20 GB enough for 50+B+I+H2; 100 GB for 181+B+I+H2
+
+plotting:
+  map:
+    boundaries: [-11, 30, 34, 71]
+    color_geomap:
+      ocean: white
+      land: whitesmoke
+  costs_max: 10
+  costs_threshold: 0.2
+  energy_max: 20000
+  energy_min: -20000
+  energy_threshold: 15
+  vre_techs:
+  - onwind
+  - offwind-ac
+  - offwind-dc
+  - solar
+  - ror
+  renewable_storage_techs:
+  - PHS
+  - hydro
+  conv_techs:
+  - OCGT
+  - CCGT
+  - Nuclear
+  - Coal
+  storage_techs:
+  - hydro+PHS
+  - battery
+  - H2
+  load_carriers:
+  - AC load
+  AC_carriers:
+  - AC line
+  - AC transformer
+  link_carriers:
+  - DC line
+  - Converter AC-DC
+  heat_links:
+  - heat pump
+  - resistive heater
+  - CHP heat
+  - CHP electric
+  - gas boiler
+  - central heat pump
+  - central resistive heater
+  - central CHP heat
+  - central CHP electric
+  - central gas boiler
+  heat_generators:
+  - gas boiler
+  - central gas boiler
+  - solar thermal collector
+  - central solar thermal collector
+  tech_colors:
+    SMR CC: "darkblue"
+    gas for industry CC: "brown"
+    process emissions CC: "gray"
+    CO2 pipeline: "gray"
+    onwind: "dodgerblue"
+    onwind2: "dodgerblue"
+    onwind3: "dodgerblue"
+    onwind4: "dodgerblue"
+    onshore wind: "#235ebc"
+    offwind: "#6895dd"
+    offshore wind: "#6895dd"
+    offwind-ac: "c"
+    offshore wind (AC): "#6895dd"
+    offwind-dc: "#74c6f2"
+    offshore wind (DC): "#74c6f2"
+    wave: '#004444'
+    hydro: '#3B5323'
+    hydro reservoir: '#3B5323'
+    ror: '#78AB46'
+    run of river: '#78AB46'
+    hydroelectricity: 'blue'
+    solar: "orange"
+    solar PV: "#f9d002"
+    solar thermal: coral
+    solar rooftop: '#ffef60'
+    OCGT: wheat
+    OCGT marginal: sandybrown
+    OCGT-heat: '#ee8340'
+    gas boiler: '#ee8340'
+    gas boilers: '#ee8340'
+    gas boiler marginal: '#ee8340'
+    gas-to-power/heat: 'brown'
+    gas: brown
+    natural gas: brown
+    SMR: '#4F4F2F'
+    oil: '#B5A642'
+    oil EOP: '#B5A642'
+    oil boiler: '#B5A677'
+    lines: k
+    transmission lines: k
+    H2: m
+    H2 electrolysis: m
+    H2 liquefaction: m
+    hydrogen storage: m
+    battery: slategray
+    battery storage: slategray
+    home battery: '#614700'
+    home battery storage: '#614700'
+    Nuclear: r
+    Nuclear marginal: r
+    nuclear: r
+    uranium: r
+    Coal: k
+    coal: k
+    industry coal emissions: '#444444'
+    Coal marginal: k
+    Lignite: grey
+    lignite: grey
+    Lignite marginal: grey
+    CCGT: '#ee8340'
+    CCGT marginal: '#ee8340'
+    heat pumps: '#76EE00'
+    heat pump: '#76EE00'
+    air heat pump: '#76EE00'
+    ground heat pump: '#40AA00'
+    power-to-heat: 'red'
+    resistive heater: pink
+    Sabatier: '#FF1493'
+    methanation: '#FF1493'
+    power-to-gas: 'purple'
+    power-to-liquid: 'darkgreen'
+    helmeth: '#7D0552'
+    DAC: 'deeppink'
+    co2 stored: '#123456'
+    CO2 sequestration: '#123456'
+    CC: k
+    co2: '#123456'
+    co2 vent: '#654321'
+    agriculture heat: '#D07A7A'
+    agriculture oil: '#1e1e1e'
+    agriculture machinery oil: '#1e1e1e'
+    agriculture machinery oil emissions: '#111111'
+    agriculture electricity: '#222222'
+    solid biomass for industry co2 from atmosphere: '#654321'
+    solid biomass for industry co2 to stored: '#654321'
+    solid biomass for industry CC: '#654321'
+    gas for industry co2 to atmosphere: '#654321'
+    gas emissions: '#654321'
+    gas for industry co2 to stored: '#654321'
+    Fischer-Tropsch: '#44DD33'
+    kerosene for aviation: '#44BB11'
+    naphtha for industry: '#44FF55'
+    land transport oil: '#44DD33'
+    rail transport oil: '#44DD33'
+    water tanks: '#BBBBBB'
+    hot water storage: '#BBBBBB'
+    hot water charging: '#BBBBBB'
+    hot water discharging: '#999999'
+    # CO2 pipeline: '#999999'
+    CHP: r
+    CHP heat: r
+    CHP electric: r
+    PHS: g
+    Ambient: k
+    Electric load: b
+    Heat load: r
+    heat: darkred
+    rural heat: '#880000'
+    central heat: '#b22222'
+    decentral heat: '#800000'
+    low-temperature heat for industry: '#991111'
+    process heat: '#FF3333'
+    heat demand: darkred
+    electric demand: k
+    Li ion: grey
+    district heating: '#CC4E5C'
+    retrofitting: purple
+    building retrofitting: purple
+    BEV charger: grey
+    V2G: grey
+    land transport EV: grey
+    electricity: k
+    gas for industry: '#333333'
+    solid biomass for industry: '#555555'
+    industry electricity: '#222222'
+    industry new electricity: '#222222'
+    process emissions to stored: '#444444'
+    process emissions to atmosphere: '#888888'
+    process emissions: '#222222'
+    oil emissions: '#666666'
+    industry oil emissions: '#666666'
+    land transport oil emissions: '#666666'
+    land transport fuel cell: '#AAAAAA'
+    biogas: '#800000'
+    solid biomass: '#DAA520'
+    today: '#D2691E'
+    shipping: '#6495ED'
+    shipping oil: "#6495ED"
+    shipping oil emissions: "#6495ED"
+    electricity distribution grid: 'y'
+    solid biomass transport: green
+    H2 for industry: "#222222"
+    H2 for shipping: "#6495ED"
+    biomass EOP: "green"
+    biomass: "green"
+    high-temp electrolysis: "magenta"
+    oil pipeline: "grey"
+    agriculture biomass: "green"
+    H2 pipeline: m

--- a/config.bright_ref_high.yaml
+++ b/config.bright_ref_high.yaml
@@ -114,7 +114,7 @@ costs: # Costs used in PyPSA-Earth-Sec. Year depends on the wildcard planning_ho
     H2: 0.
     battery: 0.
 
-  electrolyzer_cc: [0.5,1]
+  electrolyzer_cc: [0.5, 1]
 
   emission_prices: # only used with the option Ep (emission prices)
     co2: 0.

--- a/config.bright_ref_low.yaml
+++ b/config.bright_ref_low.yaml
@@ -114,7 +114,7 @@ costs: # Costs used in PyPSA-Earth-Sec. Year depends on the wildcard planning_ho
     H2: 0.
     battery: 0.
 
-  electrolyzer_cc: [0.5,1]
+  electrolyzer_cc: [0.5, 1]
 
   emission_prices: # only used with the option Ep (emission prices)
     co2: 0.

--- a/config.bright_ref_low.yaml
+++ b/config.bright_ref_low.yaml
@@ -1,0 +1,659 @@
+logging_level: INFO
+tutorial: false
+
+results_dir: results/
+summary_dir: results/
+costs_dir: data/ #TODO change to the equivalent of technology data
+
+run:
+  name: 241107_ir_sensitivity
+  name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
+  shared_cutouts: true  # set to true to share the default cutout(s) across runs
+                        # Note: value false requires build_cutout to be enabled
+
+foresight: overnight
+
+# option to disable the subworkflow to ease the analyses
+disable_subworkflow: false
+
+scenario:
+  simpl: # only relevant for PyPSA-Eur
+  - ""
+  clusters: # number of nodes in Europe, any integer between 37 (1 node per country-zone) and several hundred
+  - 11
+  planning_horizons: # investment years for myopic and perfect; or costs year for overnight
+  - 2035
+  ll:
+  - "v1.0"
+  opts:
+  - "Co2L"
+  sopts:
+  - "3H"
+  demand: ["BI", "DE", "GH"] # BI/DE/GH
+
+policy_config:
+  hydrogen:
+    temporal_matching: "hour" #either "hour", "month", "year", "no_res_matching"
+    spatial_matching: false
+    additionality: true # RE electricity is equal to the amount required for additional hydrogen export compared to the 0 export case ("reference_case")
+    allowed_excess: 1.0
+    is_reference: true # Whether or not this network is a reference case network, relevant only if additionality is _true_
+    remove_h2_load: false #Whether or not to remove the h2 load from the network, relevant only if is_reference is _true_
+    path_to_ref: "" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
+    limit_SMR_dispatch: true # Limits the dispatch of SMR to the reference case
+  renewables:
+    ratio_rooftop_to_utility_solar: 2 # insert value to activate, leave empty to disable
+
+    re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
+
+clustering_options:
+  alternative_clustering: true
+
+countries: ['BR']
+
+demand_data:
+  update_data: true # if true, the workflow downloads the energy balances data saved in data/demand/unsd/data again. Turn on for the first run.
+  base_year: 2019
+
+  other_industries: false # Whether or not to include industries that are not specified. some countries have has exageratted numbers, check carefully.
+  aluminium_year: 2019 # Year of the aluminium demand data specified in `data/AL_production.csv`
+
+
+enable:
+  retrieve_cost_data: true # if true, the workflow overwrites the cost data saved in data/costs again
+
+fossil_reserves:
+  oil: 2000 #TWh Maybe reduntant
+
+
+export:
+  h2export: [0] #,20,30,40,50,60,70,80,90,100] or "endogenous" in combination with h2mp # Yearly export demand in TWh
+  h2mp: "endogenous" # Global hydrogen market price in EUR/MWh if h2export is set to endogenous else "endogenous"
+  store: false # [True, False] # specifies wether an export store to balance demand is implemented
+  store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
+  export_profile: "constant" # use "ship" or "constant"
+  constant_nodal_export: true
+  ship:
+    ship_capacity: 0.4 # TWh # 0.05 TWh for new ones, 0.003 TWh for Susio Frontier, 0.4 TWh according to Hampp2021: "Corresponds to 11360 t H2 (l) with LHV of 33.3333 Mwh/t_H2. Cihlar et al 2020 based on IEA 2019, Table 3-B"
+    travel_time: 288 # hours # From Agadir to Rotterdam and back (12*24)
+    fill_time: 24 # hours, for 48h see Hampp2021
+    unload_time: 24 # hours for 48h see Hampp2021
+
+custom_data:
+  renewables_enertile: ["onwind", "onwind_rest", "solar", "solar-rooftop"]
+  renewables: ["onwind", "onwind2", "onwind3", "onwind4", "solar", "solar-rooftop"] # ['csp', 'rooftop-solar', 'solar']
+  energy_totals: true
+  elec_demand: true
+  heat_demand: false
+  industry_demand: true
+  industry_database: true
+  transport_demand: false
+  water_costs: false
+  h2_underground: false
+  add_existing: false
+  custom_sectors: false
+  gas_network: false # If "True" then a custom .csv file must be placed in "resources/custom_data/pipelines.csv" , If "False" the user can choose btw "greenfield" or Model built-in datasets. Please refer to ["sector"] below.
+  rename_industry_carriers: {"Electricity": "electricity", "Biofuels": "solid biomass", "Heat": "low-temperature heat", "Natural Gas": "gas", "Coal": "coal", "Hydrogen": "hydrogen", "Oil": "oil"}
+
+costs: # Costs used in PyPSA-Earth-Sec. Year depends on the wildcard planning_horizon in the scenario section
+  version: v0.9.2
+  lifetime: 25 #default lifetime
+  # From a Lion Hirth paper, also reflects average of Noothout et al 2016
+  discountrate: [0.06] #, 0.086, 0.111]
+  # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html # noqa: E501
+  USD2013_to_EUR2013: 0.7532
+
+  # Marginal and capital costs can be overwritten
+  # capital_cost:
+  #   onwind: 500
+  marginal_cost:
+    solar: 0.01
+    onwind: 0.015
+    offwind: 0.015
+    hydro: 0.
+    H2: 0.
+    battery: 0.
+
+  electrolyzer_cc: [0.5,1]
+
+  emission_prices: # only used with the option Ep (emission prices)
+    co2: 0.
+
+  lines:
+    length_factor: 1.25 #to estimate offwind connection costs
+
+
+industry:
+  St_primary_fraction: 0.9 # fraction of steel produced via primary route versus secondary route (scrap+EAF); today fraction is 0.6
+    # 2020: 0.6
+    # 2025: 0.55
+    # 2030: 0.5
+    # 2035: 0.45
+    # 2040: 0.4
+    # 2045: 0.35
+    # 2050: 0.3
+  DRI_fraction: 0.5 # fraction of the primary route converted to DRI + EAF
+    # 2020: 0
+    # 2025: 0
+    # 2030: 0.05
+    # 2035: 0.2
+    # 2040: 0.4
+    # 2045: 0.7
+    # 2050: 1
+  H2_DRI: 1.7   #H2 consumption in Direct Reduced Iron (DRI),  MWh_H2,LHV/ton_Steel from 51kgH2/tSt in Vogl et al (2018) doi:10.1016/j.jclepro.2018.08.279
+  elec_DRI: 0.322   #electricity consumption in Direct Reduced Iron (DRI) shaft, MWh/tSt HYBRIT brochure https://ssabwebsitecdn.azureedge.net/-/media/hybrit/files/hybrit_brochure.pdf
+  Al_primary_fraction: 0.2 # fraction of aluminium produced via the primary route versus scrap; today fraction is 0.4
+    # 2020: 0.4
+    # 2025: 0.375
+    # 2030: 0.35
+    # 2035: 0.325
+    # 2040: 0.3
+    # 2045: 0.25
+    # 2050: 0.2
+  MWh_CH4_per_tNH3_SMR: 10.8 # 2012's demand from https://ec.europa.eu/docsroom/documents/4165/attachments/1/translations/en/renditions/pdf
+  MWh_elec_per_tNH3_SMR: 0.7 # same source, assuming 94-6% split methane-elec of total energy demand 11.5 MWh/tNH3
+  MWh_H2_per_tNH3_electrolysis: 6.5 # from https://doi.org/10.1016/j.joule.2018.04.017, around 0.197 tH2/tHN3 (>3/17 since some H2 lost and used for energy)
+  MWh_elec_per_tNH3_electrolysis: 1.17 # from https://doi.org/10.1016/j.joule.2018.04.017 Table 13 (air separation and HB)
+  NH3_process_emissions: 24.5 # in MtCO2/a from SMR for H2 production for NH3 from UNFCCC for 2015 for EU28
+  petrochemical_process_emissions: 25.5 # in MtCO2/a for petrochemical and other from UNFCCC for 2015 for EU28
+  HVC_primary_fraction: 1. # fraction of today's HVC produced via primary route
+  HVC_mechanical_recycling_fraction: 0. # fraction of today's HVC produced via mechanical recycling
+  HVC_chemical_recycling_fraction: 0. # fraction of today's HVC produced via chemical recycling
+  HVC_production_today: 52. # MtHVC/a from DECHEMA (2017), Figure 16, page 107; includes ethylene, propylene and BTX
+  MWh_elec_per_tHVC_mechanical_recycling: 0.547 # from SI of https://doi.org/10.1016/j.resconrec.2020.105010, Table S5, for HDPE, PP, PS, PET. LDPE would be 0.756.
+  MWh_elec_per_tHVC_chemical_recycling: 6.9 # Material Economics (2019), page 125; based on pyrolysis and electric steam cracking
+  chlorine_production_today: 9.58 # MtCl/a from DECHEMA (2017), Table 7, page 43
+  MWh_elec_per_tCl: 3.6 # DECHEMA (2017), Table 6, page 43
+  MWh_H2_per_tCl: -0.9372  # DECHEMA (2017), page 43; negative since hydrogen produced in chloralkali process
+  methanol_production_today: 1.5 # MtMeOH/a from DECHEMA (2017), page 62
+  MWh_elec_per_tMeOH: 0.167 # DECHEMA (2017), Table 14, page 65
+  MWh_CH4_per_tMeOH: 10.25 # DECHEMA (2017), Table 14, page 65
+  hotmaps_locate_missing: false
+  reference_year: 2015
+
+solar_thermal:
+  clearsky_model: simple
+  orientation:
+    slope: 45.
+    azimuth: 180.
+
+existing_capacities:
+  grouping_years_power: [1960, 1965, 1970, 1975, 1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025, 2030]
+  grouping_years_heat: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2019] # these should not extend 2020
+  threshold_capacity: 10
+  default_heating_lifetime: 20
+  conventional_carriers:
+  - lignite
+  - coal
+  - oil
+  - uranium
+
+sector:
+  gas:
+    spatial_gas: true # ALWAYS TRUE
+    network: false # ALWAYS FALSE for now (NOT USED)
+    network_data: GGIT # Global dataset -> 'GGIT' , European dataset -> 'IGGIELGN'
+    network_data_GGIT_status: ['Construction', 'Operating', 'Idle', 'Shelved', 'Mothballed', 'Proposed']
+  hydrogen:
+    network: true
+    network_limit: 25000 #GWkm
+    network_routes: greenfield # "gas or "greenfield". If "gas"  ->  the network data are fetched from ["sector"]["gas"]["network_data"]. If "greenfield"  -> the network follows the topology of electrical transmission lines
+    gas_network_repurposing: true # If true -> ["sector"]["gas"]["network"] is automatically false
+    underground_storage: false
+    hydrogen_colors: false
+    set_color_shares: false
+    blue_share: 0.40
+    pink_share: 0.05
+  coal:
+    shift_to_elec: true # If true, residential and services demand of coal is shifted to electricity. If false, the final energy demand of coal is disregarded
+  international_bunkers: false #Whether or not to count the emissions of international aviation and navigation
+
+  oil:
+    spatial_oil: true
+
+  district_heating:
+    potential: 0.3 #maximum fraction of urban demand which can be supplied by district heating
+      #increase of today's district heating demand to potential maximum district heating share
+      #progress = 0 means today's district heating share, progress=-1 means maxumzm fraction of urban demand is supplied by district heating
+    progress: 1
+      #2020: 0.0
+      #2030: 0.3
+      #2040: 0.6
+      #2050: 1.0
+    district_heating_loss: 0.15
+  reduce_space_heat_exogenously: true  # reduces space heat demand by a given factor (applied before losses in DH)
+  # this can represent e.g. building renovation, building demolition, or if
+  # the factor is negative: increasing floor area, increased thermal comfort, population growth
+  reduce_space_heat_exogenously_factor: 0.29 # per unit reduction in space heat demand
+  # the default factors are determined by the LTS scenario from http://tool.european-calculator.eu/app/buildings/building-types-area/?levers=1ddd4444421213bdbbbddd44444ffffff11f411111221111211l212221
+    # 2020: 0.10  # this results in a space heat demand reduction of 10%
+    # 2025: 0.09  # first heat demand increases compared to 2020 because of larger floor area per capita
+    # 2030: 0.09
+    # 2035: 0.11
+    # 2040: 0.16
+    # 2045: 0.21
+    # 2050: 0.29
+  tes: true
+  tes_tau: # 180 day time constant for centralised, 3 day for decentralised
+    decentral: 3
+    central: 180
+  boilers: true
+  oil_boilers: false
+  chp: true
+  micro_chp: false
+  solar_thermal: true
+  heat_pump_sink_T: 55 #Celsius, based on DTU / large area radiators; used un build_cop_profiles.py
+  time_dep_hp_cop: true #time dependent heat pump coefficient of performance
+  solar_cf_correction: 0.788457 # = >>>1/1.2683
+  bev_plug_to_wheel_efficiency: 0.2 #kWh/km from EPA https://www.fueleconomy.gov/feg/ for Tesla Model S
+  bev_charge_efficiency: 0.9 #BEV (dis-)charging efficiency
+  transport_heating_deadband_upper: 20.
+  transport_heating_deadband_lower: 15.
+  ICE_lower_degree_factor: 0.375 #in per cent increase in fuel consumption per degree above deadband
+  ICE_upper_degree_factor: 1.6
+  EV_lower_degree_factor: 0.98
+  EV_upper_degree_factor: 0.63
+  bev_avail_max: 0.95
+  bev_avail_mean: 0.8
+  bev_dsm_restriction_value: 0.75 #Set to 0 for no restriction on BEV DSM
+  bev_dsm_restriction_time: 7 #Time at which SOC of BEV has to be dsm_restriction_value
+  v2g: true #allows feed-in to grid from EV battery
+  bev_dsm: true #turns on EV battery
+  bev_energy: 0.05 #average battery size in MWh
+  bev_availability: 0.5 #How many cars do smart charging
+  transport_fuel_cell_efficiency: 1
+  transport_internal_combustion_efficiency: 1
+  industry_util_factor: 0.7
+
+  biomass_transport: true  # biomass transport between nodes
+  biomass_transport_default_cost: 0.1 #EUR/km/MWh
+  solid_biomass_potential: 3604 # 4805 TWh/a for all bioenergy sources according to Welfle (2017), 75% solid, 0.28% gaseous according to IEA (2021)
+  biogas_potential: 13.5 # TWh/a, Potential of whole modelled area
+  biomass_to_liquid: true
+
+  efficiency_heat_oil_to_elec: 0.9
+  efficiency_heat_biomass_to_elec: 0.9
+  efficiency_heat_gas_to_elec: 0.9
+
+  dynamic_transport:
+    enable: false # If "True", then the BEV and FCEV shares are obtained depening on the "Co2L"-wildcard (e.g. "Co2L0.70: 0.10"). If "False", then the shares are obtained depending on the "demand" wildcard and "planning_horizons" wildcard as listed below (e.g. "DF_2050: 0.08")
+    land_transport_electric_share:
+      Co2L2.0: 0.00
+      Co2L1.0: 0.01
+      Co2L0.90: 0.03
+      Co2L0.80: 0.06
+      Co2L0.70: 0.10
+      Co2L0.60: 0.17
+      Co2L0.50: 0.27
+      Co2L0.40: 0.40
+      Co2L0.30: 0.55
+      Co2L0.20: 0.69
+      Co2L0.10: 0.80
+      Co2L0.00: 0.88
+    land_transport_fuel_cell_share:
+      Co2L2.0: 0.01
+      Co2L1.0: 0.01
+      Co2L0.90: 0.01
+      Co2L0.80: 0.01
+      Co2L0.70: 0.01
+      Co2L0.60: 0.01
+      Co2L0.50: 0.01
+      Co2L0.40: 0.01
+      Co2L0.30: 0.01
+      Co2L0.20: 0.01
+      Co2L0.10: 0.01
+      Co2L0.00: 0.01
+    bio_transport_share:
+      Co2L2.0: 0.01
+      Co2L1.0: 0.01
+      Co2L0.90: 0.01
+      Co2L0.80: 0.01
+      Co2L0.70: 0.01
+      Co2L0.60: 0.01
+      Co2L0.50: 0.01
+      Co2L0.40: 0.01
+      Co2L0.30: 0.01
+      Co2L0.20: 0.01
+      Co2L0.10: 0.01
+      Co2L0.00: 0.01
+
+  land_transport_fuel_cell_share: # 1 means all FCEVs HERE
+    BI_2030: 0.007
+    GH_2030: 0.036
+    DE_2030: 0.00
+    BI_2035: 0.026
+    GH_2035: 0.133
+    DE_2035: 0.00
+    BI_2040: 0.063
+    GH_2040: 0.266
+    DE_2040: 0.00
+    BI_2045: 0.113
+    GH_2045: 0.410
+    DE_2045: 0.021
+    BI_2050: 0.210
+    GH_2050: 0.584
+    DE_2050: 0.056
+
+  land_transport_electric_share: # 1 means all EVs  # This leads to problems when non-zero HERE
+    BI_2030: 0.022
+    GH_2030: 0.018
+    DE_2030: 0.038
+    BI_2035: 0.067
+    GH_2035: 0.054
+    DE_2035: 0.133
+    BI_2040: 0.117
+    GH_2040: 0.090
+    DE_2040: 0.264
+    BI_2045: 0.190
+    GH_2045: 0.164
+    DE_2045: 0.457
+    BI_2050: 0.301
+    GH_2050: 0.263
+    DE_2050: 0.742
+
+  bio_transport_share: # 1 means all EVs  # This leads to problems when non-zero HERE
+    BI_2030: 0.261
+    GH_2030: 0.231
+    DE_2030: 0.235
+    BI_2035: 0.343
+    GH_2035: 0.237
+    DE_2035: 0.253
+    BI_2040: 0.414
+    GH_2040: 0.222
+    DE_2040: 0.254
+    BI_2045: 0.491
+    GH_2045: 0.213
+    DE_2045: 0.261
+    BI_2050: 0.433
+    GH_2050: 0.093
+    DE_2050: 0.123
+
+
+
+  co2_network: true
+  co2_sequestration_potential: 70 #MtCO2/a sequestration potential for Europe
+  co2_sequestration_cost: 10 #EUR/tCO2 for sequestration of CO2
+  hydrogen_underground_storage: false
+  shipping_hydrogen_liquefaction: false
+  shipping_average_efficiency: 0.575 #For conversion of fuel oil to propulsion in 2011
+
+  shipping_hydrogen_share: #1.0
+    BU_2030: 0.00
+    BI_2030: 0.00
+    BI_2035: 0.014
+    GH_2030: 0.00
+    GH_2035: 0.014
+    DE_2030: 0.00
+    DE_2035: 0.014
+    AP_2030: 0.00
+    NZ_2030: 0.10
+    DF_2030: 0.05
+    AB_2030: 0.05
+    BU_2050: 0.00
+    BI_2050: 0.24
+    GH_2050: 0.248
+    DE_2050: 0.254
+    AP_2050: 0.25
+    NZ_2050: 0.36
+    DF_2050: 0.12
+
+  gadm_level: 1
+  marginal_cost_storage: 0
+  methanation: true
+  helmeth: true
+  dac: true
+  SMR: true
+  SMR CC: true
+  cc_fraction: 0.9
+  cc: true
+  space_heat_share: 0.6 # the share of space heating from all heating. Remainder goes to water heating.
+  airport_sizing_factor: 3
+
+  min_part_load_fischer_tropsch: 0.9
+
+  conventional_generation: # generator : carrier
+    OCGT: gas
+    #Gen_Test: oil # Just for testing purposes
+
+# snapshots are originally set in PyPSA-Earth/config.yaml but used again by PyPSA-Earth-Sec
+snapshots:
+  # arguments to pd.date_range
+  start: "2013-01-01"
+  end: "2014-01-01"
+  inclusive: "left" # end is not inclusive
+
+# atlite:
+#   cutout: ./cutouts/africa-2013-era5.nc
+
+build_osm_network:  # TODO: To Remove this once we merge pypsa-earth and pypsa-earth-sec
+  force_ac: true  # When true, it forces all components (lines and substation) to be AC-only. To be used if DC assets create problem.
+
+solving:
+  #tmpdir: "path/to/tmp"
+  options:
+    formulation: kirchhoff
+    clip_p_max_pu: 1.e-2
+    load_shedding: false
+    noisy_costs: true
+    skip_iterations: true
+    track_iterations: false
+    min_iterations: 4
+    max_iterations: 6
+
+  solver:
+    name: gurobi
+    threads: 25
+    method: 2 # barrier
+    crossover: 0
+    BarConvTol: 1.e-6
+    Seed: 123
+    AggFill: 0
+    PreDual: 0
+    GURO_PAR_BARDENSETHRESH: 200
+    #FeasibilityTol: 1.e-6
+
+  mem: 30000 #memory in MB; 20 GB enough for 50+B+I+H2; 100 GB for 181+B+I+H2
+
+plotting:
+  map:
+    boundaries: [-11, 30, 34, 71]
+    color_geomap:
+      ocean: white
+      land: whitesmoke
+  costs_max: 10
+  costs_threshold: 0.2
+  energy_max: 20000
+  energy_min: -20000
+  energy_threshold: 15
+  vre_techs:
+  - onwind
+  - offwind-ac
+  - offwind-dc
+  - solar
+  - ror
+  renewable_storage_techs:
+  - PHS
+  - hydro
+  conv_techs:
+  - OCGT
+  - CCGT
+  - Nuclear
+  - Coal
+  storage_techs:
+  - hydro+PHS
+  - battery
+  - H2
+  load_carriers:
+  - AC load
+  AC_carriers:
+  - AC line
+  - AC transformer
+  link_carriers:
+  - DC line
+  - Converter AC-DC
+  heat_links:
+  - heat pump
+  - resistive heater
+  - CHP heat
+  - CHP electric
+  - gas boiler
+  - central heat pump
+  - central resistive heater
+  - central CHP heat
+  - central CHP electric
+  - central gas boiler
+  heat_generators:
+  - gas boiler
+  - central gas boiler
+  - solar thermal collector
+  - central solar thermal collector
+  tech_colors:
+    SMR CC: "darkblue"
+    gas for industry CC: "brown"
+    process emissions CC: "gray"
+    CO2 pipeline: "gray"
+    onwind: "dodgerblue"
+    onwind2: "dodgerblue"
+    onwind3: "dodgerblue"
+    onwind4: "dodgerblue"
+    onshore wind: "#235ebc"
+    offwind: "#6895dd"
+    offshore wind: "#6895dd"
+    offwind-ac: "c"
+    offshore wind (AC): "#6895dd"
+    offwind-dc: "#74c6f2"
+    offshore wind (DC): "#74c6f2"
+    wave: '#004444'
+    hydro: '#3B5323'
+    hydro reservoir: '#3B5323'
+    ror: '#78AB46'
+    run of river: '#78AB46'
+    hydroelectricity: 'blue'
+    solar: "orange"
+    solar PV: "#f9d002"
+    solar thermal: coral
+    solar rooftop: '#ffef60'
+    OCGT: wheat
+    OCGT marginal: sandybrown
+    OCGT-heat: '#ee8340'
+    gas boiler: '#ee8340'
+    gas boilers: '#ee8340'
+    gas boiler marginal: '#ee8340'
+    gas-to-power/heat: 'brown'
+    gas: brown
+    natural gas: brown
+    SMR: '#4F4F2F'
+    oil: '#B5A642'
+    oil EOP: '#B5A642'
+    oil boiler: '#B5A677'
+    lines: k
+    transmission lines: k
+    H2: m
+    H2 electrolysis: m
+    H2 liquefaction: m
+    hydrogen storage: m
+    battery: slategray
+    battery storage: slategray
+    home battery: '#614700'
+    home battery storage: '#614700'
+    Nuclear: r
+    Nuclear marginal: r
+    nuclear: r
+    uranium: r
+    Coal: k
+    coal: k
+    industry coal emissions: '#444444'
+    Coal marginal: k
+    Lignite: grey
+    lignite: grey
+    Lignite marginal: grey
+    CCGT: '#ee8340'
+    CCGT marginal: '#ee8340'
+    heat pumps: '#76EE00'
+    heat pump: '#76EE00'
+    air heat pump: '#76EE00'
+    ground heat pump: '#40AA00'
+    power-to-heat: 'red'
+    resistive heater: pink
+    Sabatier: '#FF1493'
+    methanation: '#FF1493'
+    power-to-gas: 'purple'
+    power-to-liquid: 'darkgreen'
+    helmeth: '#7D0552'
+    DAC: 'deeppink'
+    co2 stored: '#123456'
+    CO2 sequestration: '#123456'
+    CC: k
+    co2: '#123456'
+    co2 vent: '#654321'
+    agriculture heat: '#D07A7A'
+    agriculture oil: '#1e1e1e'
+    agriculture machinery oil: '#1e1e1e'
+    agriculture machinery oil emissions: '#111111'
+    agriculture electricity: '#222222'
+    solid biomass for industry co2 from atmosphere: '#654321'
+    solid biomass for industry co2 to stored: '#654321'
+    solid biomass for industry CC: '#654321'
+    gas for industry co2 to atmosphere: '#654321'
+    gas emissions: '#654321'
+    gas for industry co2 to stored: '#654321'
+    Fischer-Tropsch: '#44DD33'
+    kerosene for aviation: '#44BB11'
+    naphtha for industry: '#44FF55'
+    land transport oil: '#44DD33'
+    rail transport oil: '#44DD33'
+    water tanks: '#BBBBBB'
+    hot water storage: '#BBBBBB'
+    hot water charging: '#BBBBBB'
+    hot water discharging: '#999999'
+    # CO2 pipeline: '#999999'
+    CHP: r
+    CHP heat: r
+    CHP electric: r
+    PHS: g
+    Ambient: k
+    Electric load: b
+    Heat load: r
+    heat: darkred
+    rural heat: '#880000'
+    central heat: '#b22222'
+    decentral heat: '#800000'
+    low-temperature heat for industry: '#991111'
+    process heat: '#FF3333'
+    heat demand: darkred
+    electric demand: k
+    Li ion: grey
+    district heating: '#CC4E5C'
+    retrofitting: purple
+    building retrofitting: purple
+    BEV charger: grey
+    V2G: grey
+    land transport EV: grey
+    electricity: k
+    gas for industry: '#333333'
+    solid biomass for industry: '#555555'
+    industry electricity: '#222222'
+    industry new electricity: '#222222'
+    process emissions to stored: '#444444'
+    process emissions to atmosphere: '#888888'
+    process emissions: '#222222'
+    oil emissions: '#666666'
+    industry oil emissions: '#666666'
+    land transport oil emissions: '#666666'
+    land transport fuel cell: '#AAAAAA'
+    biogas: '#800000'
+    solid biomass: '#DAA520'
+    today: '#D2691E'
+    shipping: '#6495ED'
+    shipping oil: "#6495ED"
+    shipping oil emissions: "#6495ED"
+    electricity distribution grid: 'y'
+    solid biomass transport: green
+    H2 for industry: "#222222"
+    H2 for shipping: "#6495ED"
+    biomass EOP: "green"
+    biomass: "green"
+    high-temp electrolysis: "magenta"
+    oil pipeline: "grey"
+    agriculture biomass: "green"
+    H2 pipeline: m

--- a/config.bright_ref_med.yaml
+++ b/config.bright_ref_med.yaml
@@ -1,0 +1,659 @@
+logging_level: INFO
+tutorial: false
+
+results_dir: results/
+summary_dir: results/
+costs_dir: data/ #TODO change to the equivalent of technology data
+
+run:
+  name: 241107_ir_sensitivity
+  name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
+  shared_cutouts: true  # set to true to share the default cutout(s) across runs
+                        # Note: value false requires build_cutout to be enabled
+
+foresight: overnight
+
+# option to disable the subworkflow to ease the analyses
+disable_subworkflow: false
+
+scenario:
+  simpl: # only relevant for PyPSA-Eur
+  - ""
+  clusters: # number of nodes in Europe, any integer between 37 (1 node per country-zone) and several hundred
+  - 11
+  planning_horizons: # investment years for myopic and perfect; or costs year for overnight
+  - 2035
+  ll:
+  - "v1.0"
+  opts:
+  - "Co2L"
+  sopts:
+  - "3H"
+  demand: ["BI", "DE", "GH"] # BI/DE/GH
+
+policy_config:
+  hydrogen:
+    temporal_matching: "hour" #either "hour", "month", "year", "no_res_matching"
+    spatial_matching: false
+    additionality: true # RE electricity is equal to the amount required for additional hydrogen export compared to the 0 export case ("reference_case")
+    allowed_excess: 1.0
+    is_reference: true # Whether or not this network is a reference case network, relevant only if additionality is _true_
+    remove_h2_load: false #Whether or not to remove the h2 load from the network, relevant only if is_reference is _true_
+    path_to_ref: "" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
+    limit_SMR_dispatch: true # Limits the dispatch of SMR to the reference case
+  renewables:
+    ratio_rooftop_to_utility_solar: 2 # insert value to activate, leave empty to disable
+
+    re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
+
+clustering_options:
+  alternative_clustering: true
+
+countries: ['BR']
+
+demand_data:
+  update_data: true # if true, the workflow downloads the energy balances data saved in data/demand/unsd/data again. Turn on for the first run.
+  base_year: 2019
+
+  other_industries: false # Whether or not to include industries that are not specified. some countries have has exageratted numbers, check carefully.
+  aluminium_year: 2019 # Year of the aluminium demand data specified in `data/AL_production.csv`
+
+
+enable:
+  retrieve_cost_data: true # if true, the workflow overwrites the cost data saved in data/costs again
+
+fossil_reserves:
+  oil: 2000 #TWh Maybe reduntant
+
+
+export:
+  h2export: [0] #,20,30,40,50,60,70,80,90,100] or "endogenous" in combination with h2mp # Yearly export demand in TWh
+  h2mp: "endogenous" # Global hydrogen market price in EUR/MWh if h2export is set to endogenous else "endogenous"
+  store: false # [True, False] # specifies wether an export store to balance demand is implemented
+  store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
+  export_profile: "constant" # use "ship" or "constant"
+  constant_nodal_export: true
+  ship:
+    ship_capacity: 0.4 # TWh # 0.05 TWh for new ones, 0.003 TWh for Susio Frontier, 0.4 TWh according to Hampp2021: "Corresponds to 11360 t H2 (l) with LHV of 33.3333 Mwh/t_H2. Cihlar et al 2020 based on IEA 2019, Table 3-B"
+    travel_time: 288 # hours # From Agadir to Rotterdam and back (12*24)
+    fill_time: 24 # hours, for 48h see Hampp2021
+    unload_time: 24 # hours for 48h see Hampp2021
+
+custom_data:
+  renewables_enertile: ["onwind", "onwind_rest", "solar", "solar-rooftop"]
+  renewables: ["onwind", "onwind2", "onwind3", "onwind4", "solar", "solar-rooftop"] # ['csp', 'rooftop-solar', 'solar']
+  energy_totals: true
+  elec_demand: true
+  heat_demand: false
+  industry_demand: true
+  industry_database: true
+  transport_demand: false
+  water_costs: false
+  h2_underground: false
+  add_existing: false
+  custom_sectors: false
+  gas_network: false # If "True" then a custom .csv file must be placed in "resources/custom_data/pipelines.csv" , If "False" the user can choose btw "greenfield" or Model built-in datasets. Please refer to ["sector"] below.
+  rename_industry_carriers: {"Electricity": "electricity", "Biofuels": "solid biomass", "Heat": "low-temperature heat", "Natural Gas": "gas", "Coal": "coal", "Hydrogen": "hydrogen", "Oil": "oil"}
+
+costs: # Costs used in PyPSA-Earth-Sec. Year depends on the wildcard planning_horizon in the scenario section
+  version: v0.9.2
+  lifetime: 25 #default lifetime
+  # From a Lion Hirth paper, also reflects average of Noothout et al 2016
+  discountrate: [0.08] #, 0.086, 0.111]
+  # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html # noqa: E501
+  USD2013_to_EUR2013: 0.7532
+
+  # Marginal and capital costs can be overwritten
+  # capital_cost:
+  #   onwind: 500
+  marginal_cost:
+    solar: 0.01
+    onwind: 0.015
+    offwind: 0.015
+    hydro: 0.
+    H2: 0.
+    battery: 0.
+
+  electrolyzer_cc: [0.5,1]
+
+  emission_prices: # only used with the option Ep (emission prices)
+    co2: 0.
+
+  lines:
+    length_factor: 1.25 #to estimate offwind connection costs
+
+
+industry:
+  St_primary_fraction: 0.9 # fraction of steel produced via primary route versus secondary route (scrap+EAF); today fraction is 0.6
+    # 2020: 0.6
+    # 2025: 0.55
+    # 2030: 0.5
+    # 2035: 0.45
+    # 2040: 0.4
+    # 2045: 0.35
+    # 2050: 0.3
+  DRI_fraction: 0.5 # fraction of the primary route converted to DRI + EAF
+    # 2020: 0
+    # 2025: 0
+    # 2030: 0.05
+    # 2035: 0.2
+    # 2040: 0.4
+    # 2045: 0.7
+    # 2050: 1
+  H2_DRI: 1.7   #H2 consumption in Direct Reduced Iron (DRI),  MWh_H2,LHV/ton_Steel from 51kgH2/tSt in Vogl et al (2018) doi:10.1016/j.jclepro.2018.08.279
+  elec_DRI: 0.322   #electricity consumption in Direct Reduced Iron (DRI) shaft, MWh/tSt HYBRIT brochure https://ssabwebsitecdn.azureedge.net/-/media/hybrit/files/hybrit_brochure.pdf
+  Al_primary_fraction: 0.2 # fraction of aluminium produced via the primary route versus scrap; today fraction is 0.4
+    # 2020: 0.4
+    # 2025: 0.375
+    # 2030: 0.35
+    # 2035: 0.325
+    # 2040: 0.3
+    # 2045: 0.25
+    # 2050: 0.2
+  MWh_CH4_per_tNH3_SMR: 10.8 # 2012's demand from https://ec.europa.eu/docsroom/documents/4165/attachments/1/translations/en/renditions/pdf
+  MWh_elec_per_tNH3_SMR: 0.7 # same source, assuming 94-6% split methane-elec of total energy demand 11.5 MWh/tNH3
+  MWh_H2_per_tNH3_electrolysis: 6.5 # from https://doi.org/10.1016/j.joule.2018.04.017, around 0.197 tH2/tHN3 (>3/17 since some H2 lost and used for energy)
+  MWh_elec_per_tNH3_electrolysis: 1.17 # from https://doi.org/10.1016/j.joule.2018.04.017 Table 13 (air separation and HB)
+  NH3_process_emissions: 24.5 # in MtCO2/a from SMR for H2 production for NH3 from UNFCCC for 2015 for EU28
+  petrochemical_process_emissions: 25.5 # in MtCO2/a for petrochemical and other from UNFCCC for 2015 for EU28
+  HVC_primary_fraction: 1. # fraction of today's HVC produced via primary route
+  HVC_mechanical_recycling_fraction: 0. # fraction of today's HVC produced via mechanical recycling
+  HVC_chemical_recycling_fraction: 0. # fraction of today's HVC produced via chemical recycling
+  HVC_production_today: 52. # MtHVC/a from DECHEMA (2017), Figure 16, page 107; includes ethylene, propylene and BTX
+  MWh_elec_per_tHVC_mechanical_recycling: 0.547 # from SI of https://doi.org/10.1016/j.resconrec.2020.105010, Table S5, for HDPE, PP, PS, PET. LDPE would be 0.756.
+  MWh_elec_per_tHVC_chemical_recycling: 6.9 # Material Economics (2019), page 125; based on pyrolysis and electric steam cracking
+  chlorine_production_today: 9.58 # MtCl/a from DECHEMA (2017), Table 7, page 43
+  MWh_elec_per_tCl: 3.6 # DECHEMA (2017), Table 6, page 43
+  MWh_H2_per_tCl: -0.9372  # DECHEMA (2017), page 43; negative since hydrogen produced in chloralkali process
+  methanol_production_today: 1.5 # MtMeOH/a from DECHEMA (2017), page 62
+  MWh_elec_per_tMeOH: 0.167 # DECHEMA (2017), Table 14, page 65
+  MWh_CH4_per_tMeOH: 10.25 # DECHEMA (2017), Table 14, page 65
+  hotmaps_locate_missing: false
+  reference_year: 2015
+
+solar_thermal:
+  clearsky_model: simple
+  orientation:
+    slope: 45.
+    azimuth: 180.
+
+existing_capacities:
+  grouping_years_power: [1960, 1965, 1970, 1975, 1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025, 2030]
+  grouping_years_heat: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2019] # these should not extend 2020
+  threshold_capacity: 10
+  default_heating_lifetime: 20
+  conventional_carriers:
+  - lignite
+  - coal
+  - oil
+  - uranium
+
+sector:
+  gas:
+    spatial_gas: true # ALWAYS TRUE
+    network: false # ALWAYS FALSE for now (NOT USED)
+    network_data: GGIT # Global dataset -> 'GGIT' , European dataset -> 'IGGIELGN'
+    network_data_GGIT_status: ['Construction', 'Operating', 'Idle', 'Shelved', 'Mothballed', 'Proposed']
+  hydrogen:
+    network: true
+    network_limit: 25000 #GWkm
+    network_routes: greenfield # "gas or "greenfield". If "gas"  ->  the network data are fetched from ["sector"]["gas"]["network_data"]. If "greenfield"  -> the network follows the topology of electrical transmission lines
+    gas_network_repurposing: true # If true -> ["sector"]["gas"]["network"] is automatically false
+    underground_storage: false
+    hydrogen_colors: false
+    set_color_shares: false
+    blue_share: 0.40
+    pink_share: 0.05
+  coal:
+    shift_to_elec: true # If true, residential and services demand of coal is shifted to electricity. If false, the final energy demand of coal is disregarded
+  international_bunkers: false #Whether or not to count the emissions of international aviation and navigation
+
+  oil:
+    spatial_oil: true
+
+  district_heating:
+    potential: 0.3 #maximum fraction of urban demand which can be supplied by district heating
+      #increase of today's district heating demand to potential maximum district heating share
+      #progress = 0 means today's district heating share, progress=-1 means maxumzm fraction of urban demand is supplied by district heating
+    progress: 1
+      #2020: 0.0
+      #2030: 0.3
+      #2040: 0.6
+      #2050: 1.0
+    district_heating_loss: 0.15
+  reduce_space_heat_exogenously: true  # reduces space heat demand by a given factor (applied before losses in DH)
+  # this can represent e.g. building renovation, building demolition, or if
+  # the factor is negative: increasing floor area, increased thermal comfort, population growth
+  reduce_space_heat_exogenously_factor: 0.29 # per unit reduction in space heat demand
+  # the default factors are determined by the LTS scenario from http://tool.european-calculator.eu/app/buildings/building-types-area/?levers=1ddd4444421213bdbbbddd44444ffffff11f411111221111211l212221
+    # 2020: 0.10  # this results in a space heat demand reduction of 10%
+    # 2025: 0.09  # first heat demand increases compared to 2020 because of larger floor area per capita
+    # 2030: 0.09
+    # 2035: 0.11
+    # 2040: 0.16
+    # 2045: 0.21
+    # 2050: 0.29
+  tes: true
+  tes_tau: # 180 day time constant for centralised, 3 day for decentralised
+    decentral: 3
+    central: 180
+  boilers: true
+  oil_boilers: false
+  chp: true
+  micro_chp: false
+  solar_thermal: true
+  heat_pump_sink_T: 55 #Celsius, based on DTU / large area radiators; used un build_cop_profiles.py
+  time_dep_hp_cop: true #time dependent heat pump coefficient of performance
+  solar_cf_correction: 0.788457 # = >>>1/1.2683
+  bev_plug_to_wheel_efficiency: 0.2 #kWh/km from EPA https://www.fueleconomy.gov/feg/ for Tesla Model S
+  bev_charge_efficiency: 0.9 #BEV (dis-)charging efficiency
+  transport_heating_deadband_upper: 20.
+  transport_heating_deadband_lower: 15.
+  ICE_lower_degree_factor: 0.375 #in per cent increase in fuel consumption per degree above deadband
+  ICE_upper_degree_factor: 1.6
+  EV_lower_degree_factor: 0.98
+  EV_upper_degree_factor: 0.63
+  bev_avail_max: 0.95
+  bev_avail_mean: 0.8
+  bev_dsm_restriction_value: 0.75 #Set to 0 for no restriction on BEV DSM
+  bev_dsm_restriction_time: 7 #Time at which SOC of BEV has to be dsm_restriction_value
+  v2g: true #allows feed-in to grid from EV battery
+  bev_dsm: true #turns on EV battery
+  bev_energy: 0.05 #average battery size in MWh
+  bev_availability: 0.5 #How many cars do smart charging
+  transport_fuel_cell_efficiency: 1
+  transport_internal_combustion_efficiency: 1
+  industry_util_factor: 0.7
+
+  biomass_transport: true  # biomass transport between nodes
+  biomass_transport_default_cost: 0.1 #EUR/km/MWh
+  solid_biomass_potential: 3604 # 4805 TWh/a for all bioenergy sources according to Welfle (2017), 75% solid, 0.28% gaseous according to IEA (2021)
+  biogas_potential: 13.5 # TWh/a, Potential of whole modelled area
+  biomass_to_liquid: true
+
+  efficiency_heat_oil_to_elec: 0.9
+  efficiency_heat_biomass_to_elec: 0.9
+  efficiency_heat_gas_to_elec: 0.9
+
+  dynamic_transport:
+    enable: false # If "True", then the BEV and FCEV shares are obtained depening on the "Co2L"-wildcard (e.g. "Co2L0.70: 0.10"). If "False", then the shares are obtained depending on the "demand" wildcard and "planning_horizons" wildcard as listed below (e.g. "DF_2050: 0.08")
+    land_transport_electric_share:
+      Co2L2.0: 0.00
+      Co2L1.0: 0.01
+      Co2L0.90: 0.03
+      Co2L0.80: 0.06
+      Co2L0.70: 0.10
+      Co2L0.60: 0.17
+      Co2L0.50: 0.27
+      Co2L0.40: 0.40
+      Co2L0.30: 0.55
+      Co2L0.20: 0.69
+      Co2L0.10: 0.80
+      Co2L0.00: 0.88
+    land_transport_fuel_cell_share:
+      Co2L2.0: 0.01
+      Co2L1.0: 0.01
+      Co2L0.90: 0.01
+      Co2L0.80: 0.01
+      Co2L0.70: 0.01
+      Co2L0.60: 0.01
+      Co2L0.50: 0.01
+      Co2L0.40: 0.01
+      Co2L0.30: 0.01
+      Co2L0.20: 0.01
+      Co2L0.10: 0.01
+      Co2L0.00: 0.01
+    bio_transport_share:
+      Co2L2.0: 0.01
+      Co2L1.0: 0.01
+      Co2L0.90: 0.01
+      Co2L0.80: 0.01
+      Co2L0.70: 0.01
+      Co2L0.60: 0.01
+      Co2L0.50: 0.01
+      Co2L0.40: 0.01
+      Co2L0.30: 0.01
+      Co2L0.20: 0.01
+      Co2L0.10: 0.01
+      Co2L0.00: 0.01
+
+  land_transport_fuel_cell_share: # 1 means all FCEVs HERE
+    BI_2030: 0.007
+    GH_2030: 0.036
+    DE_2030: 0.00
+    BI_2035: 0.026
+    GH_2035: 0.133
+    DE_2035: 0.00
+    BI_2040: 0.063
+    GH_2040: 0.266
+    DE_2040: 0.00
+    BI_2045: 0.113
+    GH_2045: 0.410
+    DE_2045: 0.021
+    BI_2050: 0.210
+    GH_2050: 0.584
+    DE_2050: 0.056
+
+  land_transport_electric_share: # 1 means all EVs  # This leads to problems when non-zero HERE
+    BI_2030: 0.022
+    GH_2030: 0.018
+    DE_2030: 0.038
+    BI_2035: 0.067
+    GH_2035: 0.054
+    DE_2035: 0.133
+    BI_2040: 0.117
+    GH_2040: 0.090
+    DE_2040: 0.264
+    BI_2045: 0.190
+    GH_2045: 0.164
+    DE_2045: 0.457
+    BI_2050: 0.301
+    GH_2050: 0.263
+    DE_2050: 0.742
+
+  bio_transport_share: # 1 means all EVs  # This leads to problems when non-zero HERE
+    BI_2030: 0.261
+    GH_2030: 0.231
+    DE_2030: 0.235
+    BI_2035: 0.343
+    GH_2035: 0.237
+    DE_2035: 0.253
+    BI_2040: 0.414
+    GH_2040: 0.222
+    DE_2040: 0.254
+    BI_2045: 0.491
+    GH_2045: 0.213
+    DE_2045: 0.261
+    BI_2050: 0.433
+    GH_2050: 0.093
+    DE_2050: 0.123
+
+
+
+  co2_network: true
+  co2_sequestration_potential: 70 #MtCO2/a sequestration potential for Europe
+  co2_sequestration_cost: 10 #EUR/tCO2 for sequestration of CO2
+  hydrogen_underground_storage: false
+  shipping_hydrogen_liquefaction: false
+  shipping_average_efficiency: 0.575 #For conversion of fuel oil to propulsion in 2011
+
+  shipping_hydrogen_share: #1.0
+    BU_2030: 0.00
+    BI_2030: 0.00
+    BI_2035: 0.014
+    GH_2030: 0.00
+    GH_2035: 0.014
+    DE_2030: 0.00
+    DE_2035: 0.014
+    AP_2030: 0.00
+    NZ_2030: 0.10
+    DF_2030: 0.05
+    AB_2030: 0.05
+    BU_2050: 0.00
+    BI_2050: 0.24
+    GH_2050: 0.248
+    DE_2050: 0.254
+    AP_2050: 0.25
+    NZ_2050: 0.36
+    DF_2050: 0.12
+
+  gadm_level: 1
+  marginal_cost_storage: 0
+  methanation: true
+  helmeth: true
+  dac: true
+  SMR: true
+  SMR CC: true
+  cc_fraction: 0.9
+  cc: true
+  space_heat_share: 0.6 # the share of space heating from all heating. Remainder goes to water heating.
+  airport_sizing_factor: 3
+
+  min_part_load_fischer_tropsch: 0.9
+
+  conventional_generation: # generator : carrier
+    OCGT: gas
+    #Gen_Test: oil # Just for testing purposes
+
+# snapshots are originally set in PyPSA-Earth/config.yaml but used again by PyPSA-Earth-Sec
+snapshots:
+  # arguments to pd.date_range
+  start: "2013-01-01"
+  end: "2014-01-01"
+  inclusive: "left" # end is not inclusive
+
+# atlite:
+#   cutout: ./cutouts/africa-2013-era5.nc
+
+build_osm_network:  # TODO: To Remove this once we merge pypsa-earth and pypsa-earth-sec
+  force_ac: true  # When true, it forces all components (lines and substation) to be AC-only. To be used if DC assets create problem.
+
+solving:
+  #tmpdir: "path/to/tmp"
+  options:
+    formulation: kirchhoff
+    clip_p_max_pu: 1.e-2
+    load_shedding: false
+    noisy_costs: true
+    skip_iterations: true
+    track_iterations: false
+    min_iterations: 4
+    max_iterations: 6
+
+  solver:
+    name: gurobi
+    threads: 25
+    method: 2 # barrier
+    crossover: 0
+    BarConvTol: 1.e-6
+    Seed: 123
+    AggFill: 0
+    PreDual: 0
+    GURO_PAR_BARDENSETHRESH: 200
+    #FeasibilityTol: 1.e-6
+
+  mem: 30000 #memory in MB; 20 GB enough for 50+B+I+H2; 100 GB for 181+B+I+H2
+
+plotting:
+  map:
+    boundaries: [-11, 30, 34, 71]
+    color_geomap:
+      ocean: white
+      land: whitesmoke
+  costs_max: 10
+  costs_threshold: 0.2
+  energy_max: 20000
+  energy_min: -20000
+  energy_threshold: 15
+  vre_techs:
+  - onwind
+  - offwind-ac
+  - offwind-dc
+  - solar
+  - ror
+  renewable_storage_techs:
+  - PHS
+  - hydro
+  conv_techs:
+  - OCGT
+  - CCGT
+  - Nuclear
+  - Coal
+  storage_techs:
+  - hydro+PHS
+  - battery
+  - H2
+  load_carriers:
+  - AC load
+  AC_carriers:
+  - AC line
+  - AC transformer
+  link_carriers:
+  - DC line
+  - Converter AC-DC
+  heat_links:
+  - heat pump
+  - resistive heater
+  - CHP heat
+  - CHP electric
+  - gas boiler
+  - central heat pump
+  - central resistive heater
+  - central CHP heat
+  - central CHP electric
+  - central gas boiler
+  heat_generators:
+  - gas boiler
+  - central gas boiler
+  - solar thermal collector
+  - central solar thermal collector
+  tech_colors:
+    SMR CC: "darkblue"
+    gas for industry CC: "brown"
+    process emissions CC: "gray"
+    CO2 pipeline: "gray"
+    onwind: "dodgerblue"
+    onwind2: "dodgerblue"
+    onwind3: "dodgerblue"
+    onwind4: "dodgerblue"
+    onshore wind: "#235ebc"
+    offwind: "#6895dd"
+    offshore wind: "#6895dd"
+    offwind-ac: "c"
+    offshore wind (AC): "#6895dd"
+    offwind-dc: "#74c6f2"
+    offshore wind (DC): "#74c6f2"
+    wave: '#004444'
+    hydro: '#3B5323'
+    hydro reservoir: '#3B5323'
+    ror: '#78AB46'
+    run of river: '#78AB46'
+    hydroelectricity: 'blue'
+    solar: "orange"
+    solar PV: "#f9d002"
+    solar thermal: coral
+    solar rooftop: '#ffef60'
+    OCGT: wheat
+    OCGT marginal: sandybrown
+    OCGT-heat: '#ee8340'
+    gas boiler: '#ee8340'
+    gas boilers: '#ee8340'
+    gas boiler marginal: '#ee8340'
+    gas-to-power/heat: 'brown'
+    gas: brown
+    natural gas: brown
+    SMR: '#4F4F2F'
+    oil: '#B5A642'
+    oil EOP: '#B5A642'
+    oil boiler: '#B5A677'
+    lines: k
+    transmission lines: k
+    H2: m
+    H2 electrolysis: m
+    H2 liquefaction: m
+    hydrogen storage: m
+    battery: slategray
+    battery storage: slategray
+    home battery: '#614700'
+    home battery storage: '#614700'
+    Nuclear: r
+    Nuclear marginal: r
+    nuclear: r
+    uranium: r
+    Coal: k
+    coal: k
+    industry coal emissions: '#444444'
+    Coal marginal: k
+    Lignite: grey
+    lignite: grey
+    Lignite marginal: grey
+    CCGT: '#ee8340'
+    CCGT marginal: '#ee8340'
+    heat pumps: '#76EE00'
+    heat pump: '#76EE00'
+    air heat pump: '#76EE00'
+    ground heat pump: '#40AA00'
+    power-to-heat: 'red'
+    resistive heater: pink
+    Sabatier: '#FF1493'
+    methanation: '#FF1493'
+    power-to-gas: 'purple'
+    power-to-liquid: 'darkgreen'
+    helmeth: '#7D0552'
+    DAC: 'deeppink'
+    co2 stored: '#123456'
+    CO2 sequestration: '#123456'
+    CC: k
+    co2: '#123456'
+    co2 vent: '#654321'
+    agriculture heat: '#D07A7A'
+    agriculture oil: '#1e1e1e'
+    agriculture machinery oil: '#1e1e1e'
+    agriculture machinery oil emissions: '#111111'
+    agriculture electricity: '#222222'
+    solid biomass for industry co2 from atmosphere: '#654321'
+    solid biomass for industry co2 to stored: '#654321'
+    solid biomass for industry CC: '#654321'
+    gas for industry co2 to atmosphere: '#654321'
+    gas emissions: '#654321'
+    gas for industry co2 to stored: '#654321'
+    Fischer-Tropsch: '#44DD33'
+    kerosene for aviation: '#44BB11'
+    naphtha for industry: '#44FF55'
+    land transport oil: '#44DD33'
+    rail transport oil: '#44DD33'
+    water tanks: '#BBBBBB'
+    hot water storage: '#BBBBBB'
+    hot water charging: '#BBBBBB'
+    hot water discharging: '#999999'
+    # CO2 pipeline: '#999999'
+    CHP: r
+    CHP heat: r
+    CHP electric: r
+    PHS: g
+    Ambient: k
+    Electric load: b
+    Heat load: r
+    heat: darkred
+    rural heat: '#880000'
+    central heat: '#b22222'
+    decentral heat: '#800000'
+    low-temperature heat for industry: '#991111'
+    process heat: '#FF3333'
+    heat demand: darkred
+    electric demand: k
+    Li ion: grey
+    district heating: '#CC4E5C'
+    retrofitting: purple
+    building retrofitting: purple
+    BEV charger: grey
+    V2G: grey
+    land transport EV: grey
+    electricity: k
+    gas for industry: '#333333'
+    solid biomass for industry: '#555555'
+    industry electricity: '#222222'
+    industry new electricity: '#222222'
+    process emissions to stored: '#444444'
+    process emissions to atmosphere: '#888888'
+    process emissions: '#222222'
+    oil emissions: '#666666'
+    industry oil emissions: '#666666'
+    land transport oil emissions: '#666666'
+    land transport fuel cell: '#AAAAAA'
+    biogas: '#800000'
+    solid biomass: '#DAA520'
+    today: '#D2691E'
+    shipping: '#6495ED'
+    shipping oil: "#6495ED"
+    shipping oil emissions: "#6495ED"
+    electricity distribution grid: 'y'
+    solid biomass transport: green
+    H2 for industry: "#222222"
+    H2 for shipping: "#6495ED"
+    biomass EOP: "green"
+    biomass: "green"
+    high-temp electrolysis: "magenta"
+    oil pipeline: "grey"
+    agriculture biomass: "green"
+    H2 pipeline: m

--- a/config.bright_ref_med.yaml
+++ b/config.bright_ref_med.yaml
@@ -114,7 +114,7 @@ costs: # Costs used in PyPSA-Earth-Sec. Year depends on the wildcard planning_ho
     H2: 0.
     battery: 0.
 
-  electrolyzer_cc: [0.5,1]
+  electrolyzer_cc: [0.5, 1]
 
   emission_prices: # only used with the option Ep (emission prices)
     co2: 0.

--- a/config.bright_ref_vhigh.yaml
+++ b/config.bright_ref_vhigh.yaml
@@ -1,0 +1,659 @@
+logging_level: INFO
+tutorial: false
+
+results_dir: results/
+summary_dir: results/
+costs_dir: data/ #TODO change to the equivalent of technology data
+
+run:
+  name: 241107_ir_sensitivity
+  name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
+  shared_cutouts: true  # set to true to share the default cutout(s) across runs
+                        # Note: value false requires build_cutout to be enabled
+
+foresight: overnight
+
+# option to disable the subworkflow to ease the analyses
+disable_subworkflow: false
+
+scenario:
+  simpl: # only relevant for PyPSA-Eur
+  - ""
+  clusters: # number of nodes in Europe, any integer between 37 (1 node per country-zone) and several hundred
+  - 11
+  planning_horizons: # investment years for myopic and perfect; or costs year for overnight
+  - 2035
+  ll:
+  - "v1.0"
+  opts:
+  - "Co2L"
+  sopts:
+  - "3H"
+  demand: ["BI", "DE", "GH"] # BI/DE/GH
+
+policy_config:
+  hydrogen:
+    temporal_matching: "hour" #either "hour", "month", "year", "no_res_matching"
+    spatial_matching: false
+    additionality: true # RE electricity is equal to the amount required for additional hydrogen export compared to the 0 export case ("reference_case")
+    allowed_excess: 1.0
+    is_reference: true # Whether or not this network is a reference case network, relevant only if additionality is _true_
+    remove_h2_load: false #Whether or not to remove the h2 load from the network, relevant only if is_reference is _true_
+    path_to_ref: "" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
+    limit_SMR_dispatch: true # Limits the dispatch of SMR to the reference case
+  renewables:
+    ratio_rooftop_to_utility_solar: 2 # insert value to activate, leave empty to disable
+
+    re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
+
+clustering_options:
+  alternative_clustering: true
+
+countries: ['BR']
+
+demand_data:
+  update_data: true # if true, the workflow downloads the energy balances data saved in data/demand/unsd/data again. Turn on for the first run.
+  base_year: 2019
+
+  other_industries: false # Whether or not to include industries that are not specified. some countries have has exageratted numbers, check carefully.
+  aluminium_year: 2019 # Year of the aluminium demand data specified in `data/AL_production.csv`
+
+
+enable:
+  retrieve_cost_data: true # if true, the workflow overwrites the cost data saved in data/costs again
+
+fossil_reserves:
+  oil: 2000 #TWh Maybe reduntant
+
+
+export:
+  h2export: [0] #,20,30,40,50,60,70,80,90,100] or "endogenous" in combination with h2mp # Yearly export demand in TWh
+  h2mp: "endogenous" # Global hydrogen market price in EUR/MWh if h2export is set to endogenous else "endogenous"
+  store: false # [True, False] # specifies wether an export store to balance demand is implemented
+  store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
+  export_profile: "constant" # use "ship" or "constant"
+  constant_nodal_export: true
+  ship:
+    ship_capacity: 0.4 # TWh # 0.05 TWh for new ones, 0.003 TWh for Susio Frontier, 0.4 TWh according to Hampp2021: "Corresponds to 11360 t H2 (l) with LHV of 33.3333 Mwh/t_H2. Cihlar et al 2020 based on IEA 2019, Table 3-B"
+    travel_time: 288 # hours # From Agadir to Rotterdam and back (12*24)
+    fill_time: 24 # hours, for 48h see Hampp2021
+    unload_time: 24 # hours for 48h see Hampp2021
+
+custom_data:
+  renewables_enertile: ["onwind", "onwind_rest", "solar", "solar-rooftop"]
+  renewables: ["onwind", "onwind2", "onwind3", "onwind4", "solar", "solar-rooftop"] # ['csp', 'rooftop-solar', 'solar']
+  energy_totals: true
+  elec_demand: true
+  heat_demand: false
+  industry_demand: true
+  industry_database: true
+  transport_demand: false
+  water_costs: false
+  h2_underground: false
+  add_existing: false
+  custom_sectors: false
+  gas_network: false # If "True" then a custom .csv file must be placed in "resources/custom_data/pipelines.csv" , If "False" the user can choose btw "greenfield" or Model built-in datasets. Please refer to ["sector"] below.
+  rename_industry_carriers: {"Electricity": "electricity", "Biofuels": "solid biomass", "Heat": "low-temperature heat", "Natural Gas": "gas", "Coal": "coal", "Hydrogen": "hydrogen", "Oil": "oil"}
+
+costs: # Costs used in PyPSA-Earth-Sec. Year depends on the wildcard planning_horizon in the scenario section
+  version: v0.9.2
+  lifetime: 25 #default lifetime
+  # From a Lion Hirth paper, also reflects average of Noothout et al 2016
+  discountrate: [0.1] #, 0.086, 0.111]
+  # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html # noqa: E501
+  USD2013_to_EUR2013: 0.7532
+
+  # Marginal and capital costs can be overwritten
+  # capital_cost:
+  #   onwind: 500
+  marginal_cost:
+    solar: 0.01
+    onwind: 0.015
+    offwind: 0.015
+    hydro: 0.
+    H2: 0.
+    battery: 0.
+
+  electrolyzer_cc: [0.5,1]
+
+  emission_prices: # only used with the option Ep (emission prices)
+    co2: 0.
+
+  lines:
+    length_factor: 1.25 #to estimate offwind connection costs
+
+
+industry:
+  St_primary_fraction: 0.9 # fraction of steel produced via primary route versus secondary route (scrap+EAF); today fraction is 0.6
+    # 2020: 0.6
+    # 2025: 0.55
+    # 2030: 0.5
+    # 2035: 0.45
+    # 2040: 0.4
+    # 2045: 0.35
+    # 2050: 0.3
+  DRI_fraction: 0.5 # fraction of the primary route converted to DRI + EAF
+    # 2020: 0
+    # 2025: 0
+    # 2030: 0.05
+    # 2035: 0.2
+    # 2040: 0.4
+    # 2045: 0.7
+    # 2050: 1
+  H2_DRI: 1.7   #H2 consumption in Direct Reduced Iron (DRI),  MWh_H2,LHV/ton_Steel from 51kgH2/tSt in Vogl et al (2018) doi:10.1016/j.jclepro.2018.08.279
+  elec_DRI: 0.322   #electricity consumption in Direct Reduced Iron (DRI) shaft, MWh/tSt HYBRIT brochure https://ssabwebsitecdn.azureedge.net/-/media/hybrit/files/hybrit_brochure.pdf
+  Al_primary_fraction: 0.2 # fraction of aluminium produced via the primary route versus scrap; today fraction is 0.4
+    # 2020: 0.4
+    # 2025: 0.375
+    # 2030: 0.35
+    # 2035: 0.325
+    # 2040: 0.3
+    # 2045: 0.25
+    # 2050: 0.2
+  MWh_CH4_per_tNH3_SMR: 10.8 # 2012's demand from https://ec.europa.eu/docsroom/documents/4165/attachments/1/translations/en/renditions/pdf
+  MWh_elec_per_tNH3_SMR: 0.7 # same source, assuming 94-6% split methane-elec of total energy demand 11.5 MWh/tNH3
+  MWh_H2_per_tNH3_electrolysis: 6.5 # from https://doi.org/10.1016/j.joule.2018.04.017, around 0.197 tH2/tHN3 (>3/17 since some H2 lost and used for energy)
+  MWh_elec_per_tNH3_electrolysis: 1.17 # from https://doi.org/10.1016/j.joule.2018.04.017 Table 13 (air separation and HB)
+  NH3_process_emissions: 24.5 # in MtCO2/a from SMR for H2 production for NH3 from UNFCCC for 2015 for EU28
+  petrochemical_process_emissions: 25.5 # in MtCO2/a for petrochemical and other from UNFCCC for 2015 for EU28
+  HVC_primary_fraction: 1. # fraction of today's HVC produced via primary route
+  HVC_mechanical_recycling_fraction: 0. # fraction of today's HVC produced via mechanical recycling
+  HVC_chemical_recycling_fraction: 0. # fraction of today's HVC produced via chemical recycling
+  HVC_production_today: 52. # MtHVC/a from DECHEMA (2017), Figure 16, page 107; includes ethylene, propylene and BTX
+  MWh_elec_per_tHVC_mechanical_recycling: 0.547 # from SI of https://doi.org/10.1016/j.resconrec.2020.105010, Table S5, for HDPE, PP, PS, PET. LDPE would be 0.756.
+  MWh_elec_per_tHVC_chemical_recycling: 6.9 # Material Economics (2019), page 125; based on pyrolysis and electric steam cracking
+  chlorine_production_today: 9.58 # MtCl/a from DECHEMA (2017), Table 7, page 43
+  MWh_elec_per_tCl: 3.6 # DECHEMA (2017), Table 6, page 43
+  MWh_H2_per_tCl: -0.9372  # DECHEMA (2017), page 43; negative since hydrogen produced in chloralkali process
+  methanol_production_today: 1.5 # MtMeOH/a from DECHEMA (2017), page 62
+  MWh_elec_per_tMeOH: 0.167 # DECHEMA (2017), Table 14, page 65
+  MWh_CH4_per_tMeOH: 10.25 # DECHEMA (2017), Table 14, page 65
+  hotmaps_locate_missing: false
+  reference_year: 2015
+
+solar_thermal:
+  clearsky_model: simple
+  orientation:
+    slope: 45.
+    azimuth: 180.
+
+existing_capacities:
+  grouping_years_power: [1960, 1965, 1970, 1975, 1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025, 2030]
+  grouping_years_heat: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2019] # these should not extend 2020
+  threshold_capacity: 10
+  default_heating_lifetime: 20
+  conventional_carriers:
+  - lignite
+  - coal
+  - oil
+  - uranium
+
+sector:
+  gas:
+    spatial_gas: true # ALWAYS TRUE
+    network: false # ALWAYS FALSE for now (NOT USED)
+    network_data: GGIT # Global dataset -> 'GGIT' , European dataset -> 'IGGIELGN'
+    network_data_GGIT_status: ['Construction', 'Operating', 'Idle', 'Shelved', 'Mothballed', 'Proposed']
+  hydrogen:
+    network: true
+    network_limit: 25000 #GWkm
+    network_routes: greenfield # "gas or "greenfield". If "gas"  ->  the network data are fetched from ["sector"]["gas"]["network_data"]. If "greenfield"  -> the network follows the topology of electrical transmission lines
+    gas_network_repurposing: true # If true -> ["sector"]["gas"]["network"] is automatically false
+    underground_storage: false
+    hydrogen_colors: false
+    set_color_shares: false
+    blue_share: 0.40
+    pink_share: 0.05
+  coal:
+    shift_to_elec: true # If true, residential and services demand of coal is shifted to electricity. If false, the final energy demand of coal is disregarded
+  international_bunkers: false #Whether or not to count the emissions of international aviation and navigation
+
+  oil:
+    spatial_oil: true
+
+  district_heating:
+    potential: 0.3 #maximum fraction of urban demand which can be supplied by district heating
+      #increase of today's district heating demand to potential maximum district heating share
+      #progress = 0 means today's district heating share, progress=-1 means maxumzm fraction of urban demand is supplied by district heating
+    progress: 1
+      #2020: 0.0
+      #2030: 0.3
+      #2040: 0.6
+      #2050: 1.0
+    district_heating_loss: 0.15
+  reduce_space_heat_exogenously: true  # reduces space heat demand by a given factor (applied before losses in DH)
+  # this can represent e.g. building renovation, building demolition, or if
+  # the factor is negative: increasing floor area, increased thermal comfort, population growth
+  reduce_space_heat_exogenously_factor: 0.29 # per unit reduction in space heat demand
+  # the default factors are determined by the LTS scenario from http://tool.european-calculator.eu/app/buildings/building-types-area/?levers=1ddd4444421213bdbbbddd44444ffffff11f411111221111211l212221
+    # 2020: 0.10  # this results in a space heat demand reduction of 10%
+    # 2025: 0.09  # first heat demand increases compared to 2020 because of larger floor area per capita
+    # 2030: 0.09
+    # 2035: 0.11
+    # 2040: 0.16
+    # 2045: 0.21
+    # 2050: 0.29
+  tes: true
+  tes_tau: # 180 day time constant for centralised, 3 day for decentralised
+    decentral: 3
+    central: 180
+  boilers: true
+  oil_boilers: false
+  chp: true
+  micro_chp: false
+  solar_thermal: true
+  heat_pump_sink_T: 55 #Celsius, based on DTU / large area radiators; used un build_cop_profiles.py
+  time_dep_hp_cop: true #time dependent heat pump coefficient of performance
+  solar_cf_correction: 0.788457 # = >>>1/1.2683
+  bev_plug_to_wheel_efficiency: 0.2 #kWh/km from EPA https://www.fueleconomy.gov/feg/ for Tesla Model S
+  bev_charge_efficiency: 0.9 #BEV (dis-)charging efficiency
+  transport_heating_deadband_upper: 20.
+  transport_heating_deadband_lower: 15.
+  ICE_lower_degree_factor: 0.375 #in per cent increase in fuel consumption per degree above deadband
+  ICE_upper_degree_factor: 1.6
+  EV_lower_degree_factor: 0.98
+  EV_upper_degree_factor: 0.63
+  bev_avail_max: 0.95
+  bev_avail_mean: 0.8
+  bev_dsm_restriction_value: 0.75 #Set to 0 for no restriction on BEV DSM
+  bev_dsm_restriction_time: 7 #Time at which SOC of BEV has to be dsm_restriction_value
+  v2g: true #allows feed-in to grid from EV battery
+  bev_dsm: true #turns on EV battery
+  bev_energy: 0.05 #average battery size in MWh
+  bev_availability: 0.5 #How many cars do smart charging
+  transport_fuel_cell_efficiency: 1
+  transport_internal_combustion_efficiency: 1
+  industry_util_factor: 0.7
+
+  biomass_transport: true  # biomass transport between nodes
+  biomass_transport_default_cost: 0.1 #EUR/km/MWh
+  solid_biomass_potential: 3604 # 4805 TWh/a for all bioenergy sources according to Welfle (2017), 75% solid, 0.28% gaseous according to IEA (2021)
+  biogas_potential: 13.5 # TWh/a, Potential of whole modelled area
+  biomass_to_liquid: true
+
+  efficiency_heat_oil_to_elec: 0.9
+  efficiency_heat_biomass_to_elec: 0.9
+  efficiency_heat_gas_to_elec: 0.9
+
+  dynamic_transport:
+    enable: false # If "True", then the BEV and FCEV shares are obtained depening on the "Co2L"-wildcard (e.g. "Co2L0.70: 0.10"). If "False", then the shares are obtained depending on the "demand" wildcard and "planning_horizons" wildcard as listed below (e.g. "DF_2050: 0.08")
+    land_transport_electric_share:
+      Co2L2.0: 0.00
+      Co2L1.0: 0.01
+      Co2L0.90: 0.03
+      Co2L0.80: 0.06
+      Co2L0.70: 0.10
+      Co2L0.60: 0.17
+      Co2L0.50: 0.27
+      Co2L0.40: 0.40
+      Co2L0.30: 0.55
+      Co2L0.20: 0.69
+      Co2L0.10: 0.80
+      Co2L0.00: 0.88
+    land_transport_fuel_cell_share:
+      Co2L2.0: 0.01
+      Co2L1.0: 0.01
+      Co2L0.90: 0.01
+      Co2L0.80: 0.01
+      Co2L0.70: 0.01
+      Co2L0.60: 0.01
+      Co2L0.50: 0.01
+      Co2L0.40: 0.01
+      Co2L0.30: 0.01
+      Co2L0.20: 0.01
+      Co2L0.10: 0.01
+      Co2L0.00: 0.01
+    bio_transport_share:
+      Co2L2.0: 0.01
+      Co2L1.0: 0.01
+      Co2L0.90: 0.01
+      Co2L0.80: 0.01
+      Co2L0.70: 0.01
+      Co2L0.60: 0.01
+      Co2L0.50: 0.01
+      Co2L0.40: 0.01
+      Co2L0.30: 0.01
+      Co2L0.20: 0.01
+      Co2L0.10: 0.01
+      Co2L0.00: 0.01
+
+  land_transport_fuel_cell_share: # 1 means all FCEVs HERE
+    BI_2030: 0.007
+    GH_2030: 0.036
+    DE_2030: 0.00
+    BI_2035: 0.026
+    GH_2035: 0.133
+    DE_2035: 0.00
+    BI_2040: 0.063
+    GH_2040: 0.266
+    DE_2040: 0.00
+    BI_2045: 0.113
+    GH_2045: 0.410
+    DE_2045: 0.021
+    BI_2050: 0.210
+    GH_2050: 0.584
+    DE_2050: 0.056
+
+  land_transport_electric_share: # 1 means all EVs  # This leads to problems when non-zero HERE
+    BI_2030: 0.022
+    GH_2030: 0.018
+    DE_2030: 0.038
+    BI_2035: 0.067
+    GH_2035: 0.054
+    DE_2035: 0.133
+    BI_2040: 0.117
+    GH_2040: 0.090
+    DE_2040: 0.264
+    BI_2045: 0.190
+    GH_2045: 0.164
+    DE_2045: 0.457
+    BI_2050: 0.301
+    GH_2050: 0.263
+    DE_2050: 0.742
+
+  bio_transport_share: # 1 means all EVs  # This leads to problems when non-zero HERE
+    BI_2030: 0.261
+    GH_2030: 0.231
+    DE_2030: 0.235
+    BI_2035: 0.343
+    GH_2035: 0.237
+    DE_2035: 0.253
+    BI_2040: 0.414
+    GH_2040: 0.222
+    DE_2040: 0.254
+    BI_2045: 0.491
+    GH_2045: 0.213
+    DE_2045: 0.261
+    BI_2050: 0.433
+    GH_2050: 0.093
+    DE_2050: 0.123
+
+
+
+  co2_network: true
+  co2_sequestration_potential: 70 #MtCO2/a sequestration potential for Europe
+  co2_sequestration_cost: 10 #EUR/tCO2 for sequestration of CO2
+  hydrogen_underground_storage: false
+  shipping_hydrogen_liquefaction: false
+  shipping_average_efficiency: 0.575 #For conversion of fuel oil to propulsion in 2011
+
+  shipping_hydrogen_share: #1.0
+    BU_2030: 0.00
+    BI_2030: 0.00
+    BI_2035: 0.014
+    GH_2030: 0.00
+    GH_2035: 0.014
+    DE_2030: 0.00
+    DE_2035: 0.014
+    AP_2030: 0.00
+    NZ_2030: 0.10
+    DF_2030: 0.05
+    AB_2030: 0.05
+    BU_2050: 0.00
+    BI_2050: 0.24
+    GH_2050: 0.248
+    DE_2050: 0.254
+    AP_2050: 0.25
+    NZ_2050: 0.36
+    DF_2050: 0.12
+
+  gadm_level: 1
+  marginal_cost_storage: 0
+  methanation: true
+  helmeth: true
+  dac: true
+  SMR: true
+  SMR CC: true
+  cc_fraction: 0.9
+  cc: true
+  space_heat_share: 0.6 # the share of space heating from all heating. Remainder goes to water heating.
+  airport_sizing_factor: 3
+
+  min_part_load_fischer_tropsch: 0.9
+
+  conventional_generation: # generator : carrier
+    OCGT: gas
+    #Gen_Test: oil # Just for testing purposes
+
+# snapshots are originally set in PyPSA-Earth/config.yaml but used again by PyPSA-Earth-Sec
+snapshots:
+  # arguments to pd.date_range
+  start: "2013-01-01"
+  end: "2014-01-01"
+  inclusive: "left" # end is not inclusive
+
+# atlite:
+#   cutout: ./cutouts/africa-2013-era5.nc
+
+build_osm_network:  # TODO: To Remove this once we merge pypsa-earth and pypsa-earth-sec
+  force_ac: true  # When true, it forces all components (lines and substation) to be AC-only. To be used if DC assets create problem.
+
+solving:
+  #tmpdir: "path/to/tmp"
+  options:
+    formulation: kirchhoff
+    clip_p_max_pu: 1.e-2
+    load_shedding: false
+    noisy_costs: true
+    skip_iterations: true
+    track_iterations: false
+    min_iterations: 4
+    max_iterations: 6
+
+  solver:
+    name: gurobi
+    threads: 25
+    method: 2 # barrier
+    crossover: 0
+    BarConvTol: 1.e-6
+    Seed: 123
+    AggFill: 0
+    PreDual: 0
+    GURO_PAR_BARDENSETHRESH: 200
+    #FeasibilityTol: 1.e-6
+
+  mem: 30000 #memory in MB; 20 GB enough for 50+B+I+H2; 100 GB for 181+B+I+H2
+
+plotting:
+  map:
+    boundaries: [-11, 30, 34, 71]
+    color_geomap:
+      ocean: white
+      land: whitesmoke
+  costs_max: 10
+  costs_threshold: 0.2
+  energy_max: 20000
+  energy_min: -20000
+  energy_threshold: 15
+  vre_techs:
+  - onwind
+  - offwind-ac
+  - offwind-dc
+  - solar
+  - ror
+  renewable_storage_techs:
+  - PHS
+  - hydro
+  conv_techs:
+  - OCGT
+  - CCGT
+  - Nuclear
+  - Coal
+  storage_techs:
+  - hydro+PHS
+  - battery
+  - H2
+  load_carriers:
+  - AC load
+  AC_carriers:
+  - AC line
+  - AC transformer
+  link_carriers:
+  - DC line
+  - Converter AC-DC
+  heat_links:
+  - heat pump
+  - resistive heater
+  - CHP heat
+  - CHP electric
+  - gas boiler
+  - central heat pump
+  - central resistive heater
+  - central CHP heat
+  - central CHP electric
+  - central gas boiler
+  heat_generators:
+  - gas boiler
+  - central gas boiler
+  - solar thermal collector
+  - central solar thermal collector
+  tech_colors:
+    SMR CC: "darkblue"
+    gas for industry CC: "brown"
+    process emissions CC: "gray"
+    CO2 pipeline: "gray"
+    onwind: "dodgerblue"
+    onwind2: "dodgerblue"
+    onwind3: "dodgerblue"
+    onwind4: "dodgerblue"
+    onshore wind: "#235ebc"
+    offwind: "#6895dd"
+    offshore wind: "#6895dd"
+    offwind-ac: "c"
+    offshore wind (AC): "#6895dd"
+    offwind-dc: "#74c6f2"
+    offshore wind (DC): "#74c6f2"
+    wave: '#004444'
+    hydro: '#3B5323'
+    hydro reservoir: '#3B5323'
+    ror: '#78AB46'
+    run of river: '#78AB46'
+    hydroelectricity: 'blue'
+    solar: "orange"
+    solar PV: "#f9d002"
+    solar thermal: coral
+    solar rooftop: '#ffef60'
+    OCGT: wheat
+    OCGT marginal: sandybrown
+    OCGT-heat: '#ee8340'
+    gas boiler: '#ee8340'
+    gas boilers: '#ee8340'
+    gas boiler marginal: '#ee8340'
+    gas-to-power/heat: 'brown'
+    gas: brown
+    natural gas: brown
+    SMR: '#4F4F2F'
+    oil: '#B5A642'
+    oil EOP: '#B5A642'
+    oil boiler: '#B5A677'
+    lines: k
+    transmission lines: k
+    H2: m
+    H2 electrolysis: m
+    H2 liquefaction: m
+    hydrogen storage: m
+    battery: slategray
+    battery storage: slategray
+    home battery: '#614700'
+    home battery storage: '#614700'
+    Nuclear: r
+    Nuclear marginal: r
+    nuclear: r
+    uranium: r
+    Coal: k
+    coal: k
+    industry coal emissions: '#444444'
+    Coal marginal: k
+    Lignite: grey
+    lignite: grey
+    Lignite marginal: grey
+    CCGT: '#ee8340'
+    CCGT marginal: '#ee8340'
+    heat pumps: '#76EE00'
+    heat pump: '#76EE00'
+    air heat pump: '#76EE00'
+    ground heat pump: '#40AA00'
+    power-to-heat: 'red'
+    resistive heater: pink
+    Sabatier: '#FF1493'
+    methanation: '#FF1493'
+    power-to-gas: 'purple'
+    power-to-liquid: 'darkgreen'
+    helmeth: '#7D0552'
+    DAC: 'deeppink'
+    co2 stored: '#123456'
+    CO2 sequestration: '#123456'
+    CC: k
+    co2: '#123456'
+    co2 vent: '#654321'
+    agriculture heat: '#D07A7A'
+    agriculture oil: '#1e1e1e'
+    agriculture machinery oil: '#1e1e1e'
+    agriculture machinery oil emissions: '#111111'
+    agriculture electricity: '#222222'
+    solid biomass for industry co2 from atmosphere: '#654321'
+    solid biomass for industry co2 to stored: '#654321'
+    solid biomass for industry CC: '#654321'
+    gas for industry co2 to atmosphere: '#654321'
+    gas emissions: '#654321'
+    gas for industry co2 to stored: '#654321'
+    Fischer-Tropsch: '#44DD33'
+    kerosene for aviation: '#44BB11'
+    naphtha for industry: '#44FF55'
+    land transport oil: '#44DD33'
+    rail transport oil: '#44DD33'
+    water tanks: '#BBBBBB'
+    hot water storage: '#BBBBBB'
+    hot water charging: '#BBBBBB'
+    hot water discharging: '#999999'
+    # CO2 pipeline: '#999999'
+    CHP: r
+    CHP heat: r
+    CHP electric: r
+    PHS: g
+    Ambient: k
+    Electric load: b
+    Heat load: r
+    heat: darkred
+    rural heat: '#880000'
+    central heat: '#b22222'
+    decentral heat: '#800000'
+    low-temperature heat for industry: '#991111'
+    process heat: '#FF3333'
+    heat demand: darkred
+    electric demand: k
+    Li ion: grey
+    district heating: '#CC4E5C'
+    retrofitting: purple
+    building retrofitting: purple
+    BEV charger: grey
+    V2G: grey
+    land transport EV: grey
+    electricity: k
+    gas for industry: '#333333'
+    solid biomass for industry: '#555555'
+    industry electricity: '#222222'
+    industry new electricity: '#222222'
+    process emissions to stored: '#444444'
+    process emissions to atmosphere: '#888888'
+    process emissions: '#222222'
+    oil emissions: '#666666'
+    industry oil emissions: '#666666'
+    land transport oil emissions: '#666666'
+    land transport fuel cell: '#AAAAAA'
+    biogas: '#800000'
+    solid biomass: '#DAA520'
+    today: '#D2691E'
+    shipping: '#6495ED'
+    shipping oil: "#6495ED"
+    shipping oil emissions: "#6495ED"
+    electricity distribution grid: 'y'
+    solid biomass transport: green
+    H2 for industry: "#222222"
+    H2 for shipping: "#6495ED"
+    biomass EOP: "green"
+    biomass: "green"
+    high-temp electrolysis: "magenta"
+    oil pipeline: "grey"
+    agriculture biomass: "green"
+    H2 pipeline: m

--- a/config.bright_ref_vhigh.yaml
+++ b/config.bright_ref_vhigh.yaml
@@ -114,7 +114,7 @@ costs: # Costs used in PyPSA-Earth-Sec. Year depends on the wildcard planning_ho
     H2: 0.
     battery: 0.
 
-  electrolyzer_cc: [0.5,1]
+  electrolyzer_cc: [0.5, 1]
 
   emission_prices: # only used with the option Ep (emission prices)
     co2: 0.

--- a/config.bright_ref_vhigh.yaml
+++ b/config.bright_ref_vhigh.yaml
@@ -99,7 +99,7 @@ costs: # Costs used in PyPSA-Earth-Sec. Year depends on the wildcard planning_ho
   version: v0.9.2
   lifetime: 25 #default lifetime
   # From a Lion Hirth paper, also reflects average of Noothout et al 2016
-  discountrate: [0.1] #, 0.086, 0.111]
+  discountrate: [0.12] #, 0.086, 0.111]
   # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html # noqa: E501
   USD2013_to_EUR2013: 0.7532
 

--- a/config.bright_vhigh.yaml
+++ b/config.bright_vhigh.yaml
@@ -98,7 +98,7 @@ costs: # Costs used in PyPSA-Earth-Sec. Year depends on the wildcard planning_ho
   version: v0.9.2
   lifetime: 25 #default lifetime
   # From a Lion Hirth paper, also reflects average of Noothout et al 2016
-  discountrate: [0.1] #, 0.086, 0.111]
+  discountrate: [0.12] #, 0.086, 0.111]
   # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html # noqa: E501
   USD2013_to_EUR2013: 0.7532
 

--- a/config.bright_vhigh.yaml
+++ b/config.bright_vhigh.yaml
@@ -1,0 +1,656 @@
+logging_level: INFO
+tutorial: false
+
+results_dir: results/
+summary_dir: results/
+costs_dir: data/ #TODO change to the equivalent of technology data
+
+run:
+  name: 241107_ir_sensitivity
+  name_subworkflow: ""  # scenario name of the pypsa-earth subworkflow
+  shared_cutouts: true  # set to true to share the default cutout(s) across runs
+                        # Note: value false requires build_cutout to be enabled
+
+foresight: overnight
+
+# option to disable the subworkflow to ease the analyses
+disable_subworkflow: false
+
+scenario:
+  simpl: # only relevant for PyPSA-Eur
+  - ""
+  clusters: # number of nodes in Europe, any integer between 37 (1 node per country-zone) and several hundred
+  - 11
+  planning_horizons: # investment years for myopic and perfect; or costs year for overnight
+  - 2035
+  ll:
+  - "v1.0"
+  opts:
+  - "Co2L"
+  sopts:
+  - "3H"
+  demand: ["BI", "DE", "GH"] # BI/DE/GH
+
+policy_config:
+  hydrogen:
+    temporal_matching: "hour" #either "hour", "month", "year", "no_res_matching"
+    spatial_matching: false
+    additionality: true # RE electricity is equal to the amount required for additional hydrogen export compared to the 0 export case ("reference_case")
+    allowed_excess: 1.0
+    is_reference: false # Whether or not this network is a reference case network, relevant only if additionality is _true_
+    remove_h2_load: false #Whether or not to remove the h2 load from the network, relevant only if is_reference is _true_
+    path_to_ref: "/scratch/htc/cschauss/BRIGHT/submodules/pypsa-earth-sec/results/241107_ir_sensitivity/postnetworks/elec_s_11_ec_lv1.0_Co2L_3H_2035_0.1_scenario_0export_endogenousmp.nc" # Path to the reference case network for additionality calculation, relevant only if additionality is _true_ and is_reference is _false_
+    limit_SMR_dispatch: true # Limits the dispatch of SMR to the reference case
+    re_country_load: false # Set to "True" to force the RE electricity to be equal to the electricity required for hydrogen export and the country electricity load. "False" excludes the country electricity load from the constraint.
+  renewables:
+    ratio_rooftop_to_utility_solar:  # insert value to activate, leave empty to disable
+
+clustering_options:
+  alternative_clustering: true
+
+countries: ['BR']
+
+demand_data:
+  update_data: true # if true, the workflow downloads the energy balances data saved in data/demand/unsd/data again. Turn on for the first run.
+  base_year: 2019
+
+  other_industries: false # Whether or not to include industries that are not specified. some countries have has exageratted numbers, check carefully.
+  aluminium_year: 2019 # Year of the aluminium demand data specified in `data/AL_production.csv`
+
+
+enable:
+  retrieve_cost_data: true # if true, the workflow overwrites the cost data saved in data/costs again
+
+fossil_reserves:
+  oil: 2000 #TWh Maybe reduntant
+
+
+export:
+  h2export: "endogenous" #,20,30,40,50,60,70,80,90,100] or "endogenous" in combination with h2mp # Yearly export demand in TWh
+  h2mp: [70, 72.5, 75, 77.5, 80, 82.5, 85, 87.5, 90] # Global hydrogen market price in EUR/MWh if h2export is set to endogenous
+  store: false # [True, False] # specifies wether an export store to balance demand is implemented
+  store_capital_costs: "no_costs" # ["standard_costs", "no_costs"] # specifies the costs of the export store. "standard_costs" takes CAPEX of "hydrogen storage tank type 1 including compressor"
+  export_profile: "constant" # use "ship" or "constant"
+  constant_nodal_export: true
+  ship:
+    ship_capacity: 0.4 # TWh # 0.05 TWh for new ones, 0.003 TWh for Susio Frontier, 0.4 TWh according to Hampp2021: "Corresponds to 11360 t H2 (l) with LHV of 33.3333 Mwh/t_H2. Cihlar et al 2020 based on IEA 2019, Table 3-B"
+    travel_time: 288 # hours # From Agadir to Rotterdam and back (12*24)
+    fill_time: 24 # hours, for 48h see Hampp2021
+    unload_time: 24 # hours for 48h see Hampp2021
+
+custom_data:
+  renewables_enertile: ["onwind", "onwind_rest", "solar", "solar-rooftop"]
+  renewables: ["onwind", "onwind2", "onwind3", "onwind4", "solar", "solar-rooftop"] # ['csp', 'rooftop-solar', 'solar']
+  energy_totals: true
+  elec_demand: true
+  heat_demand: false
+  industry_demand: true
+  industry_database: true
+  transport_demand: false
+  water_costs: false
+  h2_underground: false
+  add_existing: false
+  custom_sectors: false
+  gas_network: false # If "True" then a custom .csv file must be placed in "resources/custom_data/pipelines.csv" , If "False" the user can choose btw "greenfield" or Model built-in datasets. Please refer to ["sector"] below.
+  rename_industry_carriers: {"Electricity": "electricity", "Biofuels": "solid biomass", "Heat": "low-temperature heat", "Natural Gas": "gas", "Coal": "coal", "Hydrogen": "hydrogen", "Oil": "oil"}
+
+costs: # Costs used in PyPSA-Earth-Sec. Year depends on the wildcard planning_horizon in the scenario section
+  version: v0.9.2
+  lifetime: 25 #default lifetime
+  # From a Lion Hirth paper, also reflects average of Noothout et al 2016
+  discountrate: [0.1] #, 0.086, 0.111]
+  # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html # noqa: E501
+  USD2013_to_EUR2013: 0.7532
+
+  # Marginal and capital costs can be overwritten
+  # capital_cost:
+  #   onwind: 500
+  marginal_cost:
+    solar: 0.01
+    onwind: 0.015
+    offwind: 0.015
+    hydro: 0.
+    H2: 0.
+    battery: 0.
+
+  electrolyzer_cc: [0.5, 1]
+
+  emission_prices: # only used with the option Ep (emission prices)
+    co2: 0.
+
+  lines:
+    length_factor: 1.25 #to estimate offwind connection costs
+
+
+industry:
+  St_primary_fraction: 0.9 # fraction of steel produced via primary route versus secondary route (scrap+EAF); today fraction is 0.6
+    # 2020: 0.6
+    # 2025: 0.55
+    # 2030: 0.5
+    # 2035: 0.45
+    # 2040: 0.4
+    # 2045: 0.35
+    # 2050: 0.3
+  DRI_fraction: 0.5 # fraction of the primary route converted to DRI + EAF
+    # 2020: 0
+    # 2025: 0
+    # 2030: 0.05
+    # 2035: 0.2
+    # 2040: 0.4
+    # 2045: 0.7
+    # 2050: 1
+  H2_DRI: 1.7   #H2 consumption in Direct Reduced Iron (DRI),  MWh_H2,LHV/ton_Steel from 51kgH2/tSt in Vogl et al (2018) doi:10.1016/j.jclepro.2018.08.279
+  elec_DRI: 0.322   #electricity consumption in Direct Reduced Iron (DRI) shaft, MWh/tSt HYBRIT brochure https://ssabwebsitecdn.azureedge.net/-/media/hybrit/files/hybrit_brochure.pdf
+  Al_primary_fraction: 0.2 # fraction of aluminium produced via the primary route versus scrap; today fraction is 0.4
+    # 2020: 0.4
+    # 2025: 0.375
+    # 2030: 0.35
+    # 2035: 0.325
+    # 2040: 0.3
+    # 2045: 0.25
+    # 2050: 0.2
+  MWh_CH4_per_tNH3_SMR: 10.8 # 2012's demand from https://ec.europa.eu/docsroom/documents/4165/attachments/1/translations/en/renditions/pdf
+  MWh_elec_per_tNH3_SMR: 0.7 # same source, assuming 94-6% split methane-elec of total energy demand 11.5 MWh/tNH3
+  MWh_H2_per_tNH3_electrolysis: 6.5 # from https://doi.org/10.1016/j.joule.2018.04.017, around 0.197 tH2/tHN3 (>3/17 since some H2 lost and used for energy)
+  MWh_elec_per_tNH3_electrolysis: 1.17 # from https://doi.org/10.1016/j.joule.2018.04.017 Table 13 (air separation and HB)
+  NH3_process_emissions: 24.5 # in MtCO2/a from SMR for H2 production for NH3 from UNFCCC for 2015 for EU28
+  petrochemical_process_emissions: 25.5 # in MtCO2/a for petrochemical and other from UNFCCC for 2015 for EU28
+  HVC_primary_fraction: 1. # fraction of today's HVC produced via primary route
+  HVC_mechanical_recycling_fraction: 0. # fraction of today's HVC produced via mechanical recycling
+  HVC_chemical_recycling_fraction: 0. # fraction of today's HVC produced via chemical recycling
+  HVC_production_today: 52. # MtHVC/a from DECHEMA (2017), Figure 16, page 107; includes ethylene, propylene and BTX
+  MWh_elec_per_tHVC_mechanical_recycling: 0.547 # from SI of https://doi.org/10.1016/j.resconrec.2020.105010, Table S5, for HDPE, PP, PS, PET. LDPE would be 0.756.
+  MWh_elec_per_tHVC_chemical_recycling: 6.9 # Material Economics (2019), page 125; based on pyrolysis and electric steam cracking
+  chlorine_production_today: 9.58 # MtCl/a from DECHEMA (2017), Table 7, page 43
+  MWh_elec_per_tCl: 3.6 # DECHEMA (2017), Table 6, page 43
+  MWh_H2_per_tCl: -0.9372  # DECHEMA (2017), page 43; negative since hydrogen produced in chloralkali process
+  methanol_production_today: 1.5 # MtMeOH/a from DECHEMA (2017), page 62
+  MWh_elec_per_tMeOH: 0.167 # DECHEMA (2017), Table 14, page 65
+  MWh_CH4_per_tMeOH: 10.25 # DECHEMA (2017), Table 14, page 65
+  hotmaps_locate_missing: false
+  reference_year: 2015
+
+solar_thermal:
+  clearsky_model: simple
+  orientation:
+    slope: 45.
+    azimuth: 180.
+
+existing_capacities:
+  grouping_years_power: [1960, 1965, 1970, 1975, 1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025, 2030]
+  grouping_years_heat: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2019] # these should not extend 2020
+  threshold_capacity: 10
+  default_heating_lifetime: 20
+  conventional_carriers:
+  - lignite
+  - coal
+  - oil
+  - uranium
+
+sector:
+  gas:
+    spatial_gas: true # ALWAYS TRUE
+    network: false # ALWAYS FALSE for now (NOT USED)
+    network_data: GGIT # Global dataset -> 'GGIT' , European dataset -> 'IGGIELGN'
+    network_data_GGIT_status: ['Construction', 'Operating', 'Idle', 'Shelved', 'Mothballed', 'Proposed']
+  hydrogen:
+    network: true
+    network_limit: 25000 #GWkm
+    network_routes: greenfield # "gas or "greenfield". If "gas"  ->  the network data are fetched from ["sector"]["gas"]["network_data"]. If "greenfield"  -> the network follows the topology of electrical transmission lines
+    gas_network_repurposing: true # If true -> ["sector"]["gas"]["network"] is automatically false
+    underground_storage: false
+    hydrogen_colors: false
+    set_color_shares: false
+    blue_share: 0.40
+    pink_share: 0.05
+  coal:
+    shift_to_elec: true # If true, residential and services demand of coal is shifted to electricity. If false, the final energy demand of coal is disregarded
+  international_bunkers: false #Whether or not to count the emissions of international aviation and navigation
+
+  oil:
+    spatial_oil: true
+
+  district_heating:
+    potential: 0.3 #maximum fraction of urban demand which can be supplied by district heating
+      #increase of today's district heating demand to potential maximum district heating share
+      #progress = 0 means today's district heating share, progress=-1 means maxumzm fraction of urban demand is supplied by district heating
+    progress: 1
+      #2020: 0.0
+      #2030: 0.3
+      #2040: 0.6
+      #2050: 1.0
+    district_heating_loss: 0.15
+  reduce_space_heat_exogenously: true  # reduces space heat demand by a given factor (applied before losses in DH)
+  # this can represent e.g. building renovation, building demolition, or if
+  # the factor is negative: increasing floor area, increased thermal comfort, population growth
+  reduce_space_heat_exogenously_factor: 0.29 # per unit reduction in space heat demand
+  # the default factors are determined by the LTS scenario from http://tool.european-calculator.eu/app/buildings/building-types-area/?levers=1ddd4444421213bdbbbddd44444ffffff11f411111221111211l212221
+    # 2020: 0.10  # this results in a space heat demand reduction of 10%
+    # 2025: 0.09  # first heat demand increases compared to 2020 because of larger floor area per capita
+    # 2030: 0.09
+    # 2035: 0.11
+    # 2040: 0.16
+    # 2045: 0.21
+    # 2050: 0.29
+  tes: true
+  tes_tau: # 180 day time constant for centralised, 3 day for decentralised
+    decentral: 3
+    central: 180
+  boilers: true
+  oil_boilers: false
+  chp: true
+  micro_chp: false
+  solar_thermal: true
+  heat_pump_sink_T: 55 #Celsius, based on DTU / large area radiators; used un build_cop_profiles.py
+  time_dep_hp_cop: true #time dependent heat pump coefficient of performance
+  solar_cf_correction: 0.788457 # = >>>1/1.2683
+  bev_plug_to_wheel_efficiency: 0.2 #kWh/km from EPA https://www.fueleconomy.gov/feg/ for Tesla Model S
+  bev_charge_efficiency: 0.9 #BEV (dis-)charging efficiency
+  transport_heating_deadband_upper: 20.
+  transport_heating_deadband_lower: 15.
+  ICE_lower_degree_factor: 0.375 #in per cent increase in fuel consumption per degree above deadband
+  ICE_upper_degree_factor: 1.6
+  EV_lower_degree_factor: 0.98
+  EV_upper_degree_factor: 0.63
+  bev_avail_max: 0.95
+  bev_avail_mean: 0.8
+  bev_dsm_restriction_value: 0.75 #Set to 0 for no restriction on BEV DSM
+  bev_dsm_restriction_time: 7 #Time at which SOC of BEV has to be dsm_restriction_value
+  v2g: true #allows feed-in to grid from EV battery
+  bev_dsm: true #turns on EV battery
+  bev_energy: 0.05 #average battery size in MWh
+  bev_availability: 0.5 #How many cars do smart charging
+  transport_fuel_cell_efficiency: 1
+  transport_internal_combustion_efficiency: 1
+  industry_util_factor: 0.7
+
+  biomass_transport: true  # biomass transport between nodes
+  biomass_transport_default_cost: 0.1 #EUR/km/MWh
+  solid_biomass_potential: 3604 # 4805 TWh/a for all bioenergy sources according to Welfle (2017), 75% solid, 0.28% gaseous according to IEA (2021)
+  biogas_potential: 13.5 # TWh/a, Potential of whole modelled area
+  biomass_to_liquid: true
+
+  efficiency_heat_oil_to_elec: 0.9
+  efficiency_heat_biomass_to_elec: 0.9
+  efficiency_heat_gas_to_elec: 0.9
+
+  dynamic_transport:
+    enable: false # If "True", then the BEV and FCEV shares are obtained depening on the "Co2L"-wildcard (e.g. "Co2L0.70: 0.10"). If "False", then the shares are obtained depending on the "demand" wildcard and "planning_horizons" wildcard as listed below (e.g. "DF_2050: 0.08")
+    land_transport_electric_share:
+      Co2L2.0: 0.00
+      Co2L1.0: 0.01
+      Co2L0.90: 0.03
+      Co2L0.80: 0.06
+      Co2L0.70: 0.10
+      Co2L0.60: 0.17
+      Co2L0.50: 0.27
+      Co2L0.40: 0.40
+      Co2L0.30: 0.55
+      Co2L0.20: 0.69
+      Co2L0.10: 0.80
+      Co2L0.00: 0.88
+    land_transport_fuel_cell_share:
+      Co2L2.0: 0.01
+      Co2L1.0: 0.01
+      Co2L0.90: 0.01
+      Co2L0.80: 0.01
+      Co2L0.70: 0.01
+      Co2L0.60: 0.01
+      Co2L0.50: 0.01
+      Co2L0.40: 0.01
+      Co2L0.30: 0.01
+      Co2L0.20: 0.01
+      Co2L0.10: 0.01
+      Co2L0.00: 0.01
+    bio_transport_share:
+      Co2L2.0: 0.01
+      Co2L1.0: 0.01
+      Co2L0.90: 0.01
+      Co2L0.80: 0.01
+      Co2L0.70: 0.01
+      Co2L0.60: 0.01
+      Co2L0.50: 0.01
+      Co2L0.40: 0.01
+      Co2L0.30: 0.01
+      Co2L0.20: 0.01
+      Co2L0.10: 0.01
+      Co2L0.00: 0.01
+
+  land_transport_fuel_cell_share: # 1 means all FCEVs HERE
+    BI_2030: 0.007
+    GH_2030: 0.036
+    DE_2030: 0.00
+    BI_2035: 0.026
+    GH_2035: 0.133
+    DE_2035: 0.00
+    BI_2040: 0.063
+    GH_2040: 0.266
+    DE_2040: 0.00
+    BI_2045: 0.113
+    GH_2045: 0.410
+    DE_2045: 0.021
+    BI_2050: 0.210
+    GH_2050: 0.584
+    DE_2050: 0.056
+
+  land_transport_electric_share: # 1 means all EVs  # This leads to problems when non-zero HERE
+    BI_2030: 0.022
+    GH_2030: 0.018
+    DE_2030: 0.038
+    BI_2035: 0.067
+    GH_2035: 0.054
+    DE_2035: 0.133
+    BI_2040: 0.117
+    GH_2040: 0.090
+    DE_2040: 0.264
+    BI_2045: 0.190
+    GH_2045: 0.164
+    DE_2045: 0.457
+    BI_2050: 0.301
+    GH_2050: 0.263
+    DE_2050: 0.742
+
+  bio_transport_share: # 1 means all EVs  # This leads to problems when non-zero HERE
+    BI_2030: 0.261
+    GH_2030: 0.231
+    DE_2030: 0.235
+    BI_2035: 0.343
+    GH_2035: 0.237
+    DE_2035: 0.253
+    BI_2040: 0.414
+    GH_2040: 0.222
+    DE_2040: 0.254
+    BI_2045: 0.491
+    GH_2045: 0.213
+    DE_2045: 0.261
+    BI_2050: 0.433
+    GH_2050: 0.093
+    DE_2050: 0.123
+
+
+
+  co2_network: true
+  co2_sequestration_potential: 70 #MtCO2/a sequestration potential for Europe
+  co2_sequestration_cost: 10 #EUR/tCO2 for sequestration of CO2
+  hydrogen_underground_storage: false
+  shipping_hydrogen_liquefaction: false
+  shipping_average_efficiency: 0.575 #For conversion of fuel oil to propulsion in 2011
+
+  shipping_hydrogen_share: #1.0
+    BI_2030: 0.0
+    GH_2030: 0.0
+    DE_2030: 0.0
+    BI_2035: 0.014
+    GH_2035: 0.014
+    DE_2035: 0.014
+    BI_2040: 0.064
+    GH_2040: 0.064
+    DE_2040: 0.065
+    BI_2045: 0.128
+    GH_2045: 0.130
+    DE_2045: 0.131
+    BI_2050: 0.240
+    GH_2050: 0.248
+    DE_2050: 0.254
+
+  gadm_level: 1
+  marginal_cost_storage: 0
+  methanation: true
+  helmeth: true
+  dac: true
+  SMR: true
+  SMR CC: true
+  cc_fraction: 0.9
+  cc: true
+  space_heat_share: 0.6 # the share of space heating from all heating. Remainder goes to water heating.
+  airport_sizing_factor: 3
+
+  min_part_load_fischer_tropsch: 0.9
+
+  conventional_generation: # generator : carrier
+    OCGT: gas
+    #Gen_Test: oil # Just for testing purposes
+
+# snapshots are originally set in PyPSA-Earth/config.yaml but used again by PyPSA-Earth-Sec
+snapshots:
+  # arguments to pd.date_range
+  start: "2013-01-01"
+  end: "2014-01-01"
+  inclusive: "left" # end is not inclusive
+
+# atlite:
+#   cutout: ./cutouts/africa-2013-era5.nc
+
+build_osm_network:  # TODO: To Remove this once we merge pypsa-earth and pypsa-earth-sec
+  force_ac: true  # When true, it forces all components (lines and substation) to be AC-only. To be used if DC assets create problem.
+
+solving:
+  #tmpdir: "path/to/tmp"
+  options:
+    formulation: kirchhoff
+    clip_p_max_pu: 1.e-2
+    load_shedding: false
+    noisy_costs: true
+    skip_iterations: true
+    track_iterations: false
+    min_iterations: 4
+    max_iterations: 6
+
+  solver:
+    name: gurobi
+    threads: 25
+    method: 2 # barrier
+    crossover: 0
+    BarConvTol: 1.e-6
+    Seed: 123
+    AggFill: 0
+    PreDual: 0
+    GURO_PAR_BARDENSETHRESH: 200
+    #FeasibilityTol: 1.e-6
+
+  mem: 30000 #memory in MB; 20 GB enough for 50+B+I+H2; 100 GB for 181+B+I+H2
+
+plotting:
+  map:
+    boundaries: [-11, 30, 34, 71]
+    color_geomap:
+      ocean: white
+      land: whitesmoke
+  costs_max: 10
+  costs_threshold: 0.2
+  energy_max: 20000
+  energy_min: -20000
+  energy_threshold: 15
+  vre_techs:
+  - onwind
+  - offwind-ac
+  - offwind-dc
+  - solar
+  - ror
+  renewable_storage_techs:
+  - PHS
+  - hydro
+  conv_techs:
+  - OCGT
+  - CCGT
+  - Nuclear
+  - Coal
+  storage_techs:
+  - hydro+PHS
+  - battery
+  - H2
+  load_carriers:
+  - AC load
+  AC_carriers:
+  - AC line
+  - AC transformer
+  link_carriers:
+  - DC line
+  - Converter AC-DC
+  heat_links:
+  - heat pump
+  - resistive heater
+  - CHP heat
+  - CHP electric
+  - gas boiler
+  - central heat pump
+  - central resistive heater
+  - central CHP heat
+  - central CHP electric
+  - central gas boiler
+  heat_generators:
+  - gas boiler
+  - central gas boiler
+  - solar thermal collector
+  - central solar thermal collector
+  tech_colors:
+    SMR CC: "darkblue"
+    gas for industry CC: "brown"
+    process emissions CC: "gray"
+    CO2 pipeline: "gray"
+    onwind: "dodgerblue"
+    onwind2: "dodgerblue"
+    onwind3: "dodgerblue"
+    onwind4: "dodgerblue"
+    onshore wind: "#235ebc"
+    offwind: "#6895dd"
+    offshore wind: "#6895dd"
+    offwind-ac: "c"
+    offshore wind (AC): "#6895dd"
+    offwind-dc: "#74c6f2"
+    offshore wind (DC): "#74c6f2"
+    wave: '#004444'
+    hydro: '#3B5323'
+    hydro reservoir: '#3B5323'
+    ror: '#78AB46'
+    run of river: '#78AB46'
+    hydroelectricity: 'blue'
+    solar: "orange"
+    solar PV: "#f9d002"
+    solar thermal: coral
+    solar rooftop: '#ffef60'
+    OCGT: wheat
+    OCGT marginal: sandybrown
+    OCGT-heat: '#ee8340'
+    gas boiler: '#ee8340'
+    gas boilers: '#ee8340'
+    gas boiler marginal: '#ee8340'
+    gas-to-power/heat: 'brown'
+    gas: brown
+    natural gas: brown
+    SMR: '#4F4F2F'
+    oil: '#B5A642'
+    oil EOP: '#B5A642'
+    oil boiler: '#B5A677'
+    lines: k
+    transmission lines: k
+    H2: m
+    H2 electrolysis: m
+    H2 liquefaction: m
+    hydrogen storage: m
+    battery: slategray
+    battery storage: slategray
+    home battery: '#614700'
+    home battery storage: '#614700'
+    Nuclear: r
+    Nuclear marginal: r
+    nuclear: r
+    uranium: r
+    Coal: k
+    coal: k
+    industry coal emissions: '#444444'
+    Coal marginal: k
+    Lignite: grey
+    lignite: grey
+    Lignite marginal: grey
+    CCGT: '#ee8340'
+    CCGT marginal: '#ee8340'
+    heat pumps: '#76EE00'
+    heat pump: '#76EE00'
+    air heat pump: '#76EE00'
+    ground heat pump: '#40AA00'
+    power-to-heat: 'red'
+    resistive heater: pink
+    Sabatier: '#FF1493'
+    methanation: '#FF1493'
+    power-to-gas: 'purple'
+    power-to-liquid: 'darkgreen'
+    helmeth: '#7D0552'
+    DAC: 'deeppink'
+    co2 stored: '#123456'
+    CO2 sequestration: '#123456'
+    CC: k
+    co2: '#123456'
+    co2 vent: '#654321'
+    agriculture heat: '#D07A7A'
+    agriculture oil: '#1e1e1e'
+    agriculture machinery oil: '#1e1e1e'
+    agriculture machinery oil emissions: '#111111'
+    agriculture electricity: '#222222'
+    solid biomass for industry co2 from atmosphere: '#654321'
+    solid biomass for industry co2 to stored: '#654321'
+    solid biomass for industry CC: '#654321'
+    gas for industry co2 to atmosphere: '#654321'
+    gas emissions: '#654321'
+    gas for industry co2 to stored: '#654321'
+    Fischer-Tropsch: '#44DD33'
+    kerosene for aviation: '#44BB11'
+    naphtha for industry: '#44FF55'
+    land transport oil: '#44DD33'
+    rail transport oil: '#44DD33'
+    water tanks: '#BBBBBB'
+    hot water storage: '#BBBBBB'
+    hot water charging: '#BBBBBB'
+    hot water discharging: '#999999'
+    # CO2 pipeline: '#999999'
+    CHP: r
+    CHP heat: r
+    CHP electric: r
+    PHS: g
+    Ambient: k
+    Electric load: b
+    Heat load: r
+    heat: darkred
+    rural heat: '#880000'
+    central heat: '#b22222'
+    decentral heat: '#800000'
+    low-temperature heat for industry: '#991111'
+    process heat: '#FF3333'
+    heat demand: darkred
+    electric demand: k
+    Li ion: grey
+    district heating: '#CC4E5C'
+    retrofitting: purple
+    building retrofitting: purple
+    BEV charger: grey
+    V2G: grey
+    land transport EV: grey
+    electricity: k
+    gas for industry: '#333333'
+    solid biomass for industry: '#555555'
+    industry electricity: '#222222'
+    industry new electricity: '#222222'
+    process emissions to stored: '#444444'
+    process emissions to atmosphere: '#888888'
+    process emissions: '#222222'
+    oil emissions: '#666666'
+    industry oil emissions: '#666666'
+    land transport oil emissions: '#666666'
+    land transport fuel cell: '#AAAAAA'
+    biogas: '#800000'
+    solid biomass: '#DAA520'
+    today: '#D2691E'
+    shipping: '#6495ED'
+    shipping oil: "#6495ED"
+    shipping oil emissions: "#6495ED"
+    electricity distribution grid: 'y'
+    solid biomass transport: green
+    H2 for industry: "#222222"
+    H2 for shipping: "#6495ED"
+    biomass EOP: "green"
+    biomass: "green"
+    high-temp electrolysis: "magenta"
+    oil pipeline: "grey"
+    agriculture biomass: "green"
+    biomass to liquid: "green"
+    H2 pipeline: m

--- a/config.pypsa-earth_high.yaml
+++ b/config.pypsa-earth_high.yaml
@@ -1,0 +1,511 @@
+# SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
+#
+# SPDX-License-Identifier: CC0-1.0
+
+version: 0.4.0
+tutorial: false
+
+logging:
+  level: INFO
+  format: "%(levelname)s:%(name)s:%(message)s"
+
+countries: ["BR"]
+# Can be replaced by country ["NG", "BJ"], continent ["Africa"] or user-specific region, see more at https://pypsa-earth.readthedocs.io/en/latest/configuration.html#top-level-configuration
+
+enable:
+  retrieve_databundle: true  #  Recommended 'true', for the first run. Otherwise data might be missing.
+  retrieve_cost_data: true  # true: retrieves cost data from technology data and saves in resources/costs.csv, false: uses cost data in data/costs.csv
+  download_osm_data: true  # If 'true', OpenStreetMap data will be downloaded for the above given countries
+  build_natura_raster: false  # If True, then an exclusion raster will be build
+  build_cutout: false
+  # If "build_cutout" : true, then environmental data is extracted according to `snapshots` date range and `countries`
+  # requires cds API key https://cds.climate.copernicus.eu/api-how-to
+  # More information https://atlite.readthedocs.io/en/latest/introduction.html#datasets
+
+custom_rules: []  # Default empty [] or link to custom rule file e.g. ["my_folder/my_rules.smk"] that add rules to Snakefile
+
+run:
+  name: "" # use this to keep track of runs with different settings
+  shared_cutouts: true  # set to true to share the default cutout(s) across runs
+                        # Note: value false requires build_cutout to be enabled
+
+scenario:
+  simpl: ['']
+  ll: ['copt']
+  clusters: [10]
+  opts: [Co2L-3H]
+
+snapshots:
+  start: "2013-01-01"
+  end: "2014-01-01"
+  inclusive: "left" # end is not inclusive
+
+# definition of the Coordinate Reference Systems
+crs:
+  geo_crs: EPSG:4326  # general geographic projection, not used for metric measures. "EPSG:4326" is the standard used by OSM and google maps
+  distance_crs: EPSG:3857  # projection for distance measurements only. Possible recommended values are "EPSG:3857" (used by OSM and Google Maps)
+  area_crs: ESRI:54009  # projection for area measurements only. Possible recommended values are Global Mollweide "ESRI:54009"
+
+# download_osm_data_nprocesses: 10  # (optional) number of threads used to download osm data
+
+augmented_line_connection:
+  add_to_snakefile: false  # If True, includes this rule to the workflow
+  connectivity_upgrade: 2  # Min. lines connection per node, https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation.html#networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation
+  new_line_type: ["HVAC"]  # Expanded lines can be either ["HVAC"] or ["HVDC"] or both ["HVAC", "HVDC"]
+  min_expansion: 1  # [MW] New created line expands by float/int input
+  min_DC_length: 600  # [km] Minimum line length of DC line
+
+cluster_options:
+  simplify_network:
+    to_substations: false # network is simplified to nodes with positive or negative power injection (i.e. substations or offwind connections)
+    algorithm: kmeans # choose from: [hac, kmeans]
+    feature: solar+onwind-time # only for hac. choose from: [solar+onwind-time, solar+onwind-cap, solar-time, solar-cap, solar+offwind-cap] etc.
+    exclude_carriers: []
+    remove_stubs: false
+    remove_stubs_across_borders: true
+    p_threshold_drop_isolated: 20 # [MW] isolated buses are being discarded if bus mean power is below the specified threshold
+    p_threshold_merge_isolated: 300 # [MW] isolated buses are being merged into a single isolated bus if a bus mean power is below the specified threshold
+    s_threshold_fetch_isolated: 0.05 # [-] a share of the national load for merging an isolated network into a backbone network
+  cluster_network:
+    algorithm: kmeans
+    feature: solar+onwind-time
+    exclude_carriers: []
+  alternative_clustering: true  # "False" use Voronoi shapes, "True" use GADM shapes
+  distribute_cluster: ['load'] # Distributes cluster nodes per country according to ['load'],['pop'] or ['gdp']
+  out_logging: true  # When "True", logging is printed to console
+  aggregation_strategies:
+    generators:  # use "min" for more conservative assumptions
+      p_nom: sum
+      p_nom_max: sum
+      p_nom_min: sum
+      p_min_pu: mean
+      marginal_cost: mean
+      committable: any
+      ramp_limit_up: max
+      ramp_limit_down: max
+      efficiency: mean
+
+build_shape_options:
+  gadm_layer_id: 1  # GADM level area used for the gadm_shapes. Codes are country-dependent but roughly: 0: country, 1: region/county-like, 2: municipality-like
+  update_file: false  # When true, all the input files are downloaded again and replace the existing files
+  out_logging: true  # When true, logging is printed to console
+  year: 2020  # reference year used to derive shapes, info on population and info on GDP
+  nprocesses: 1  # number of processes to be used in build_shapes
+  worldpop_method: "standard"  # "standard" pulls from web 1kmx1km raster, "api" pulls from API 100mx100m raster, false (not "false") no pop addition to shape which is useful when generating only cutout
+  gdp_method: "standard"  # "standard" pulls from web 1x1km raster, false (not "false") no gdp addition to shape which useful when generating only cutout
+  contended_flag: "set_by_country" # "set_by_country" assigns the contended areas to the countries according to the GADM database, "drop" drops these contended areas from the model
+
+clean_osm_data_options:  # osm = OpenStreetMap
+  names_by_shapes: true  # Set the country name based on the extended country shapes
+  threshold_voltage: 51000  # [V] assets below that voltage threshold will not be used (cable, line, generator, etc.)
+  tag_substation: "transmission"  # Filters only substations with 'transmission' tag, ('distribution' also available)
+  add_line_endings: true  # When "True", then line endings are added to the dataset of the substations
+  generator_name_method: OSM  # Methodology to specify the name to the generator. Options: OSM (name as by OSM dataset), closest_city (name by the closest city)
+  use_custom_lines: "OSM_only"  # Use OSM (OSM_only), customized (custom_only), or both data sets (add_custom)
+  path_custom_lines: false  # If exists, provide the specific absolute path of the custom file e.g. (...\data\custom_lines.geojson)
+  use_custom_substations: "OSM_only"  # Use OSM (OSM_only), customized (custom_only), or both data sets (add_custom)
+  path_custom_substations: false  # If exists, provide the specific absolute path of the custom file e.g. (...\data\custom_substations.geojson)
+  use_custom_cables: "OSM_only"  # Use OSM (OSM_only), customized (custom_only), or both data sets (add_custom)
+  path_custom_cables: false  # If exists, provide the specific absolute path of the custom file e.g. (...\data\custom_cables.geojson)
+
+build_osm_network:  # Options of the build_osm_network script; osm = OpenStreetMap
+  group_close_buses: true  # When "True", close buses are merged and guarantee the voltage matching among line endings
+  group_tolerance_buses: 5000  # [m] (default 5000) Tolerance in meters of the close buses to merge
+  split_overpassing_lines: true  # When True, lines overpassing buses are splitted and connected to the bueses
+  overpassing_lines_tolerance: 1  # [m] (default 1) Tolerance to identify lines overpassing buses
+  force_ac: true  # When true, it forces all components (lines and substation) to be AC-only. To be used if DC assets create problem.
+
+base_network:
+  min_voltage_substation_offshore: 51000  # [V] minimum voltage of the offshore substations
+  min_voltage_rebase_voltage: 51000  # [V] minimum voltage in base network
+
+load_options:
+  ssp: "ssp2-2.6" # shared socio-economic pathway (GDP and population growth) scenario to consider
+  weather_year: 2013  # Load scenarios available with different weather year (different renewable potentials)
+  prediction_year: 2030  # Load scenarios available with different prediction year (GDP, population)
+  scale: 1  # scales all load time-series, i.e. 2 = doubles load
+
+electricity:
+  base_voltage: 380.
+  voltages: [132., 220., 300., 380., 500., 750.]
+  co2limit: 274.0e+6  # European default, 0.05 * 3.1e9*0.5, needs to be adjusted for Africa
+  co2base: 1.487e+9  # European default, adjustment to Africa necessary
+  agg_p_nom_limits: data/agg_p_nom_minmax.csv
+  hvdc_as_lines: false  # should HVDC lines be modeled as `Line` or as `Link` component?
+  automatic_emission: false
+  automatic_emission_base_year: 1990 # 1990 is taken as default. Any year from 1970 to 2018 can be selected.
+
+  operational_reserve: # like https://genxproject.github.io/GenX/dev/core/#Reserves
+    activate: false
+    epsilon_load: 0.02 # share of total load
+    epsilon_vres: 0.02 # share of total renewable supply
+    contingency: 0 # fixed capacity in MW
+
+  max_hours:
+    battery: 6
+    H2: 168
+
+  extendable_carriers:
+    Generator: [solar, onwind, offwind-ac, offwind-dc, OCGT]
+    StorageUnit: []  # battery, H2
+    Store: [] #battery, H2]
+    Link: []  # H2 pipeline
+
+  powerplants_filter: (DateOut >= 2022 or DateOut != DateOut)
+  custom_powerplants: false  #  "false" use only powerplantmatching (ppm) data, "merge" combines ppm and custom powerplants, "replace" use only custom powerplants
+
+  conventional_carriers: [nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass]
+  renewable_carriers: [solar, onwind, csp, offwind-ac, offwind-dc, hydro]
+
+  estimate_renewable_capacities:
+    stats: 'irena' # False, = greenfield expansion, 'irena' uses IRENA stats to add expansion limits
+    year: 2023  # Reference year, available years for IRENA stats are 2000 to 2023
+    p_nom_min: 1  # any float, scales the minimum expansion acquired from stats, i.e. 110% of <years>'s capacities => p_nom_min: 1.1
+    p_nom_max: false  # sets the expansion constraint, False to deactivate this option and use estimated renewable potentials determine by the workflow, float scales the p_nom_min factor accordingly
+    technology_mapping:
+      # Wind is the Fueltype in ppm.data.Capacity_stats, onwind, offwind-{ac,dc} the carrier in PyPSA-Earth
+      Offshore: [offwind-ac, offwind-dc]
+      Onshore: [onwind]
+      PV: [solar]
+
+lines:
+  ac_types:
+    132.: "243-AL1/39-ST1A 20.0"
+    220.: "Al/St 240/40 2-bundle 220.0"
+    300.: "Al/St 240/40 3-bundle 300.0"
+    380.: "Al/St 240/40 4-bundle 380.0"
+    500.: "Al/St 240/40 4-bundle 380.0"
+    750.: "Al/St 560/50 4-bundle 750.0"
+  dc_types:
+    500.: "HVDC XLPE 1000"
+  s_max_pu: 0.7
+  s_nom_max: .inf
+  length_factor: 1.25
+  under_construction: "zero" # 'zero': set capacity to zero, 'remove': remove, 'keep': with full capacity
+
+links:
+  p_max_pu: 1.0
+  p_nom_max: .inf
+  under_construction: "zero" # 'zero': set capacity to zero, 'remove': remove, 'keep': with full capacity
+
+transformers:
+  x: 0.1
+  s_nom: 2000.
+  type: ""
+
+atlite:
+  nprocesses: 4
+  cutouts:
+    # geographical bounds automatically determined from countries input
+    cutout-2013-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
+      # The cutout time is automatically set by the snapshot range. See `snapshot:` option above and 'build_cutout.py'.
+      # time: ["2013-01-01", "2014-01-01"]  # to manually specify a different weather year (~70 years available)
+      # The cutout spatial extent [x,y] is automatically set by country selection. See `countires:` option above and 'build_cutout.py'.
+      # x: [-12., 35.]  # set cutout range manual, instead of automatic by boundaries of country
+      # y: [33., 72]    # manual set cutout range
+
+
+renewable:
+  onwind:
+    cutout: cutout-2013-era5
+    resource:
+      method: wind
+      turbine: Vestas_V112_3MW
+    capacity_per_sqkm: 3 # conservative, ScholzPhd Tab 4.3.1: 10MW/km^2
+    # correction_factor: 0.93
+    copernicus:
+      # Scholz, Y. (2012). Renewable energy based electricity supply at low costs:
+      #  development of the REMix model and application for Europe. ( p.42 / p.28)
+      # CLC grid codes:
+      # 11X/12X - Various forest types
+      # 20  - Shrubs
+      # 30  - Herbaceus vegetation
+      # 40  - Cropland
+      # 50  - Urban
+      # 60  - Bare / Sparse vegetation
+      # 80  - Permanent water bodies
+      # 100 - Moss and lichen
+      # 200 - Open sea
+      grid_codes: [20, 30, 40, 60, 100, 111, 112, 113, 114, 115, 116, 121, 122, 123, 124, 125, 126]
+      distance: 1000
+      distance_grid_codes: [50]
+    natura: true
+    potential: simple # or conservative
+    clip_p_max_pu: 1.e-2
+    extendable: true
+  offwind-ac:
+    cutout: cutout-2013-era5
+    resource:
+      method: wind
+      turbine: NREL_ReferenceTurbine_5MW_offshore
+    capacity_per_sqkm: 2
+    correction_factor: 0.8855
+    # proxy for wake losses
+    # from 10.1016/j.energy.2018.08.153
+    # until done more rigorously in #153
+    copernicus:
+      grid_codes: [80, 200]
+    natura: true
+    max_depth: 50
+    max_shore_distance: 30000
+    potential: simple # or conservative
+    clip_p_max_pu: 1.e-2
+    extendable: true
+  offwind-dc:
+    cutout: cutout-2013-era5
+    resource:
+      method: wind
+      turbine: NREL_ReferenceTurbine_5MW_offshore
+    # ScholzPhd Tab 4.3.1: 10MW/km^2
+    capacity_per_sqkm: 3
+    correction_factor: 0.8855
+    # proxy for wake losses
+    # from 10.1016/j.energy.2018.08.153
+    # until done more rigorously in #153
+    copernicus:
+      grid_codes: [80, 200]
+    natura: true
+    max_depth: 50
+    min_shore_distance: 30000
+    potential: simple # or conservative
+    clip_p_max_pu: 1.e-2
+    extendable: true
+  solar:
+    cutout: cutout-2013-era5
+    resource:
+      method: pv
+      panel: CSi
+      orientation: latitude_optimal # will lead into optimal design
+        # slope: 0.  # slope: 0 represent a flat panel
+        # azimuth: 180.  # azimuth: 180 south orientation
+    capacity_per_sqkm: 4.6 # From 1.7 to 4.6 addresses issue #361
+    # Determined by comparing uncorrected area-weighted full-load hours to those
+    # published in Supplementary Data to
+    # Pietzcker, Robert Carl, et al. "Using the sun to decarbonize the power
+    # sector: The economic potential of photovoltaics and concentrating solar
+    # power." Applied Energy 135 (2014): 704-720.
+    correction_factor: 0.854337
+    copernicus:
+      grid_codes: [20, 30, 40, 50, 60, 90, 100]
+    natura: true
+    potential: simple # or conservative
+    clip_p_max_pu: 1.e-2
+    extendable: true
+  hydro:
+    cutout: cutout-2013-era5
+    hydrobasins_level: 6
+    resource:
+      method: hydro
+      hydrobasins: data/hydrobasins/hybas_world.shp
+      flowspeed: 1.0  # m/s
+      # weight_with_height: false
+      # show_progress: true
+    carriers: [ror, PHS, hydro]
+    PHS_max_hours: 6
+    hydro_max_hours: "energy_capacity_totals_by_country"  # not active
+    hydro_max_hours_default: 6.0  # (optional, default 6) Default value of max_hours for hydro when NaN values are found
+    clip_min_inflow: 1.0
+    extendable: true
+    normalization:
+      method: eia  # 'hydro_capacities' to rescale country hydro production by using hydro_capacities, 'eia' to rescale by eia data, false for no rescaling
+      year: 2020  # (optional) year of statistics used to rescale the runoff time series. When not provided, the weather year of the snapshots is used
+    multiplier: 1.1  # multiplier applied after the normalization of the hydro production; default 1.0
+  csp:
+    cutout: cutout-2013-era5
+    resource:
+      method: csp
+      installation: SAM_solar_tower
+    capacity_per_sqkm: 2.392 # From 1.7 to 4.6 addresses issue #361
+    # Determined by comparing uncorrected area-weighted full-load hours to those
+    # published in Supplementary Data to
+    # Pietzcker, Robert Carl, et al. "Using the sun to decarbonize the power
+    # sector: The economic potential of photovoltaics and concentrating solar
+    # power." Applied Energy 135 (2014): 704-720.
+    copernicus:
+      grid_codes: [20, 30, 40, 60, 90]
+      distancing_codes: [50]
+      distance_to_codes: 3000
+    natura: true
+    potential: simple # or conservative
+    clip_p_max_pu: 1.e-2
+    extendable: true
+    csp_model: advanced # simple or advanced
+
+# TODO: Needs to be adjusted for Africa.
+# Costs Configuration (Do not remove, needed for Sphynx documentation).
+costs:
+  year: 2035
+  version: v0.9.2
+  rooftop_share: 0.14  # based on the potentials, assuming  (0.1 kW/m2 and 10 m2/person)
+  USD2013_to_EUR2013: 0.7532 # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html
+  fill_values:
+    FOM: 0
+    VOM: 0
+    efficiency: 1
+    fuel: 0
+    investment: 0
+    lifetime: 25
+    CO2 intensity: 0
+    discount rate: 0.1
+  marginal_cost: # EUR/MWh
+    solar: 0.01
+    onwind: 0.015
+    offwind: 0.015
+    hydro: 0.
+    H2: 0.
+    electrolysis: 0.
+    fuel cell: 0.
+    battery: 0.
+    battery inverter: 0.
+  emission_prices: # in currency per tonne emission, only used with the option Ep
+    co2: 0.
+
+
+monte_carlo:
+  # Description: Specify Monte Carlo sampling options for uncertainty analysis.
+  # Define the option list for Monte Carlo sampling.
+  # Make sure add_to_snakefile is set to true to enable Monte-Carlo
+  options:
+    add_to_snakefile: false # When set to true, enables Monte Carlo sampling
+    samples: 9 # number of optimizations. Note that number of samples when using scipy has to be the square of a prime number
+    sampling_strategy: "chaospy"  # "pydoe2", "chaospy", "scipy", packages that are supported
+    seed: 42 # set seedling for reproducibilty
+  # Uncertanties on any PyPSA object are specified by declaring the specific PyPSA object under the key 'uncertainties'.
+  # For each PyPSA object, the 'type' and 'args' keys represent the type of distribution and its argument, respectively.
+  # Supported distributions types are uniform, normal, lognormal, triangle, beta and gamma.
+  # The arguments of the distribution are passed using the key 'args'  as follows, tailored by distribution type
+  # normal: [mean, std], lognormal: [mean, std], uniform: [lower_bound, upper_bound],
+  # triangle: [mid_point (between 0 - 1)], beta: [alpha, beta], gamma: [shape, scale]
+  # More info on the distributions are documented in the Chaospy reference guide...
+  # https://chaospy.readthedocs.io/en/master/reference/distribution/index.html
+  # An abstract example is as follows:
+  # {pypsa network object, e.g. "loads_t.p_set"}:
+  # type: {any supported distribution among the previous: "uniform", "normal", ...}
+  # args: {arguments passed as a list depending on the distribution, see the above and more at https://pypsa.readthedocs.io/}
+  uncertainties:
+    loads_t.p_set:
+      type: uniform
+      args: [0, 1]
+    generators_t.p_max_pu.loc[:, n.generators.carrier == "onwind"]:
+      type: lognormal
+      args: [1.5]
+    generators_t.p_max_pu.loc[:, n.generators.carrier == "solar"]:
+      type: beta
+      args: [0.5, 2]
+
+
+
+solving:
+  options:
+    formulation: kirchhoff
+    load_shedding: true
+    noisy_costs: true
+    min_iterations: 4
+    max_iterations: 6
+    clip_p_max_pu: 0.01
+    skip_iterations: true
+    track_iterations: false
+    #nhours: 10
+  solver:
+    name: gurobi
+    threads: 4
+    method: 2 # barrier (=ipm)
+    crossover: 0
+    BarConvTol: 1.e-5
+    FeasibilityTol: 1.e-6
+    AggFill: 0
+    PreDual: 0
+    GURO_PAR_BARDENSETHRESH: 200
+
+
+plotting:
+  map:
+    figsize: [7, 7]
+    boundaries: [-10.2, 29, 35, 72]
+    p_nom:
+      bus_size_factor: 5.e+4
+      linewidth_factor: 3.e+3
+
+  costs_max: 800
+  costs_threshold: 1
+
+  energy_max: 15000.
+  energy_min: -10000.
+  energy_threshold: 50.
+
+  vre_techs: ["onwind", "offwind-ac", "offwind-dc", "solar", "ror"]
+  conv_techs: ["OCGT", "CCGT", "nuclear", "coal", "oil"]
+  storage_techs: ["hydro+PHS", "battery", "H2"]
+  load_carriers: ["AC load"]
+  AC_carriers: ["AC line", "AC transformer"]
+  link_carriers: ["DC line", "Converter AC-DC"]
+  tech_colors:
+    "onwind": "#235ebc"
+    "onshore wind": "#235ebc"
+    "offwind": "#6895dd"
+    "offwind-ac": "#6895dd"
+    "offshore wind": "#6895dd"
+    "offshore wind ac": "#6895dd"
+    "offwind-dc": "#74c6f2"
+    "offshore wind dc": "#74c6f2"
+    "hydro": "#08ad97"
+    "hydro+PHS": "#08ad97"
+    "PHS": "#08ad97"
+    "hydro reservoir": "#08ad97"
+    "hydroelectricity": "#08ad97"
+    "ror": "#4adbc8"
+    "run of river": "#4adbc8"
+    "solar": "#f9d002"
+    "solar PV": "#f9d002"
+    "solar thermal": "#ffef60"
+    "biomass": "#0c6013"
+    "solid biomass": "#06540d"
+    "biogas": "#23932d"
+    "waste": "#68896b"
+    "geothermal": "#ba91b1"
+    "OCGT": "#d35050"
+    "gas": "#d35050"
+    "natural gas": "#d35050"
+    "CCGT": "#b20101"
+    "nuclear": "#ff9000"
+    "coal": "#707070"
+    "lignite": "#9e5a01"
+    "oil": "#262626"
+    "H2": "#ea048a"
+    "hydrogen storage": "#ea048a"
+    "battery": "#b8ea04"
+    "Electric load": "#f9d002"
+    "electricity": "#f9d002"
+    "lines": "#70af1d"
+    "transmission lines": "#70af1d"
+    "AC": "#70af1d"
+    "AC-AC": "#70af1d"
+    "AC line": "#70af1d"
+    "links": "#8a1caf"
+    "HVDC links": "#8a1caf"
+    "DC": "#8a1caf"
+    "DC-DC": "#8a1caf"
+    "DC link": "#8a1caf"
+    "load": "#ff0000"
+    "load shedding": "#ff0000"
+    "battery discharger": slategray
+    "battery charger": slategray
+    "h2 fuel cell": '#c251ae'
+    "h2 electrolysis": '#ff29d9'
+    "csp": "#fdd404"
+  nice_names:
+    OCGT: "Open-Cycle Gas"
+    CCGT: "Combined-Cycle Gas"
+    offwind-ac: "Offshore Wind (AC)"
+    offwind-dc: "Offshore Wind (DC)"
+    onwind: "Onshore Wind"
+    solar: "Solar"
+    PHS: "Pumped Hydro Storage"
+    hydro: "Reservoir & Dam"
+    battery: "Battery Storage"
+    H2: "Hydrogen Storage"
+    lines: "Transmission Lines"
+    ror: "Run of River"

--- a/config.pypsa-earth_low.yaml
+++ b/config.pypsa-earth_low.yaml
@@ -1,0 +1,511 @@
+# SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
+#
+# SPDX-License-Identifier: CC0-1.0
+
+version: 0.4.0
+tutorial: false
+
+logging:
+  level: INFO
+  format: "%(levelname)s:%(name)s:%(message)s"
+
+countries: ["BR"]
+# Can be replaced by country ["NG", "BJ"], continent ["Africa"] or user-specific region, see more at https://pypsa-earth.readthedocs.io/en/latest/configuration.html#top-level-configuration
+
+enable:
+  retrieve_databundle: true  #  Recommended 'true', for the first run. Otherwise data might be missing.
+  retrieve_cost_data: true  # true: retrieves cost data from technology data and saves in resources/costs.csv, false: uses cost data in data/costs.csv
+  download_osm_data: true  # If 'true', OpenStreetMap data will be downloaded for the above given countries
+  build_natura_raster: false  # If True, then an exclusion raster will be build
+  build_cutout: false
+  # If "build_cutout" : true, then environmental data is extracted according to `snapshots` date range and `countries`
+  # requires cds API key https://cds.climate.copernicus.eu/api-how-to
+  # More information https://atlite.readthedocs.io/en/latest/introduction.html#datasets
+
+custom_rules: []  # Default empty [] or link to custom rule file e.g. ["my_folder/my_rules.smk"] that add rules to Snakefile
+
+run:
+  name: "" # use this to keep track of runs with different settings
+  shared_cutouts: true  # set to true to share the default cutout(s) across runs
+                        # Note: value false requires build_cutout to be enabled
+
+scenario:
+  simpl: ['']
+  ll: ['copt']
+  clusters: [10]
+  opts: [Co2L-3H]
+
+snapshots:
+  start: "2013-01-01"
+  end: "2014-01-01"
+  inclusive: "left" # end is not inclusive
+
+# definition of the Coordinate Reference Systems
+crs:
+  geo_crs: EPSG:4326  # general geographic projection, not used for metric measures. "EPSG:4326" is the standard used by OSM and google maps
+  distance_crs: EPSG:3857  # projection for distance measurements only. Possible recommended values are "EPSG:3857" (used by OSM and Google Maps)
+  area_crs: ESRI:54009  # projection for area measurements only. Possible recommended values are Global Mollweide "ESRI:54009"
+
+# download_osm_data_nprocesses: 10  # (optional) number of threads used to download osm data
+
+augmented_line_connection:
+  add_to_snakefile: false  # If True, includes this rule to the workflow
+  connectivity_upgrade: 2  # Min. lines connection per node, https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation.html#networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation
+  new_line_type: ["HVAC"]  # Expanded lines can be either ["HVAC"] or ["HVDC"] or both ["HVAC", "HVDC"]
+  min_expansion: 1  # [MW] New created line expands by float/int input
+  min_DC_length: 600  # [km] Minimum line length of DC line
+
+cluster_options:
+  simplify_network:
+    to_substations: false # network is simplified to nodes with positive or negative power injection (i.e. substations or offwind connections)
+    algorithm: kmeans # choose from: [hac, kmeans]
+    feature: solar+onwind-time # only for hac. choose from: [solar+onwind-time, solar+onwind-cap, solar-time, solar-cap, solar+offwind-cap] etc.
+    exclude_carriers: []
+    remove_stubs: false
+    remove_stubs_across_borders: true
+    p_threshold_drop_isolated: 20 # [MW] isolated buses are being discarded if bus mean power is below the specified threshold
+    p_threshold_merge_isolated: 300 # [MW] isolated buses are being merged into a single isolated bus if a bus mean power is below the specified threshold
+    s_threshold_fetch_isolated: 0.05 # [-] a share of the national load for merging an isolated network into a backbone network
+  cluster_network:
+    algorithm: kmeans
+    feature: solar+onwind-time
+    exclude_carriers: []
+  alternative_clustering: true  # "False" use Voronoi shapes, "True" use GADM shapes
+  distribute_cluster: ['load'] # Distributes cluster nodes per country according to ['load'],['pop'] or ['gdp']
+  out_logging: true  # When "True", logging is printed to console
+  aggregation_strategies:
+    generators:  # use "min" for more conservative assumptions
+      p_nom: sum
+      p_nom_max: sum
+      p_nom_min: sum
+      p_min_pu: mean
+      marginal_cost: mean
+      committable: any
+      ramp_limit_up: max
+      ramp_limit_down: max
+      efficiency: mean
+
+build_shape_options:
+  gadm_layer_id: 1  # GADM level area used for the gadm_shapes. Codes are country-dependent but roughly: 0: country, 1: region/county-like, 2: municipality-like
+  update_file: false  # When true, all the input files are downloaded again and replace the existing files
+  out_logging: true  # When true, logging is printed to console
+  year: 2020  # reference year used to derive shapes, info on population and info on GDP
+  nprocesses: 1  # number of processes to be used in build_shapes
+  worldpop_method: "standard"  # "standard" pulls from web 1kmx1km raster, "api" pulls from API 100mx100m raster, false (not "false") no pop addition to shape which is useful when generating only cutout
+  gdp_method: "standard"  # "standard" pulls from web 1x1km raster, false (not "false") no gdp addition to shape which useful when generating only cutout
+  contended_flag: "set_by_country" # "set_by_country" assigns the contended areas to the countries according to the GADM database, "drop" drops these contended areas from the model
+
+clean_osm_data_options:  # osm = OpenStreetMap
+  names_by_shapes: true  # Set the country name based on the extended country shapes
+  threshold_voltage: 51000  # [V] assets below that voltage threshold will not be used (cable, line, generator, etc.)
+  tag_substation: "transmission"  # Filters only substations with 'transmission' tag, ('distribution' also available)
+  add_line_endings: true  # When "True", then line endings are added to the dataset of the substations
+  generator_name_method: OSM  # Methodology to specify the name to the generator. Options: OSM (name as by OSM dataset), closest_city (name by the closest city)
+  use_custom_lines: "OSM_only"  # Use OSM (OSM_only), customized (custom_only), or both data sets (add_custom)
+  path_custom_lines: false  # If exists, provide the specific absolute path of the custom file e.g. (...\data\custom_lines.geojson)
+  use_custom_substations: "OSM_only"  # Use OSM (OSM_only), customized (custom_only), or both data sets (add_custom)
+  path_custom_substations: false  # If exists, provide the specific absolute path of the custom file e.g. (...\data\custom_substations.geojson)
+  use_custom_cables: "OSM_only"  # Use OSM (OSM_only), customized (custom_only), or both data sets (add_custom)
+  path_custom_cables: false  # If exists, provide the specific absolute path of the custom file e.g. (...\data\custom_cables.geojson)
+
+build_osm_network:  # Options of the build_osm_network script; osm = OpenStreetMap
+  group_close_buses: true  # When "True", close buses are merged and guarantee the voltage matching among line endings
+  group_tolerance_buses: 5000  # [m] (default 5000) Tolerance in meters of the close buses to merge
+  split_overpassing_lines: true  # When True, lines overpassing buses are splitted and connected to the bueses
+  overpassing_lines_tolerance: 1  # [m] (default 1) Tolerance to identify lines overpassing buses
+  force_ac: true  # When true, it forces all components (lines and substation) to be AC-only. To be used if DC assets create problem.
+
+base_network:
+  min_voltage_substation_offshore: 51000  # [V] minimum voltage of the offshore substations
+  min_voltage_rebase_voltage: 51000  # [V] minimum voltage in base network
+
+load_options:
+  ssp: "ssp2-2.6" # shared socio-economic pathway (GDP and population growth) scenario to consider
+  weather_year: 2013  # Load scenarios available with different weather year (different renewable potentials)
+  prediction_year: 2030  # Load scenarios available with different prediction year (GDP, population)
+  scale: 1  # scales all load time-series, i.e. 2 = doubles load
+
+electricity:
+  base_voltage: 380.
+  voltages: [132., 220., 300., 380., 500., 750.]
+  co2limit: 274.0e+6  # European default, 0.05 * 3.1e9*0.5, needs to be adjusted for Africa
+  co2base: 1.487e+9  # European default, adjustment to Africa necessary
+  agg_p_nom_limits: data/agg_p_nom_minmax.csv
+  hvdc_as_lines: false  # should HVDC lines be modeled as `Line` or as `Link` component?
+  automatic_emission: false
+  automatic_emission_base_year: 1990 # 1990 is taken as default. Any year from 1970 to 2018 can be selected.
+
+  operational_reserve: # like https://genxproject.github.io/GenX/dev/core/#Reserves
+    activate: false
+    epsilon_load: 0.02 # share of total load
+    epsilon_vres: 0.02 # share of total renewable supply
+    contingency: 0 # fixed capacity in MW
+
+  max_hours:
+    battery: 6
+    H2: 168
+
+  extendable_carriers:
+    Generator: [solar, onwind, offwind-ac, offwind-dc, OCGT]
+    StorageUnit: []  # battery, H2
+    Store: [] #battery, H2]
+    Link: []  # H2 pipeline
+
+  powerplants_filter: (DateOut >= 2022 or DateOut != DateOut)
+  custom_powerplants: false  #  "false" use only powerplantmatching (ppm) data, "merge" combines ppm and custom powerplants, "replace" use only custom powerplants
+
+  conventional_carriers: [nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass]
+  renewable_carriers: [solar, onwind, csp, offwind-ac, offwind-dc, hydro]
+
+  estimate_renewable_capacities:
+    stats: 'irena' # False, = greenfield expansion, 'irena' uses IRENA stats to add expansion limits
+    year: 2023  # Reference year, available years for IRENA stats are 2000 to 2023
+    p_nom_min: 1  # any float, scales the minimum expansion acquired from stats, i.e. 110% of <years>'s capacities => p_nom_min: 1.1
+    p_nom_max: false  # sets the expansion constraint, False to deactivate this option and use estimated renewable potentials determine by the workflow, float scales the p_nom_min factor accordingly
+    technology_mapping:
+      # Wind is the Fueltype in ppm.data.Capacity_stats, onwind, offwind-{ac,dc} the carrier in PyPSA-Earth
+      Offshore: [offwind-ac, offwind-dc]
+      Onshore: [onwind]
+      PV: [solar]
+
+lines:
+  ac_types:
+    132.: "243-AL1/39-ST1A 20.0"
+    220.: "Al/St 240/40 2-bundle 220.0"
+    300.: "Al/St 240/40 3-bundle 300.0"
+    380.: "Al/St 240/40 4-bundle 380.0"
+    500.: "Al/St 240/40 4-bundle 380.0"
+    750.: "Al/St 560/50 4-bundle 750.0"
+  dc_types:
+    500.: "HVDC XLPE 1000"
+  s_max_pu: 0.7
+  s_nom_max: .inf
+  length_factor: 1.25
+  under_construction: "zero" # 'zero': set capacity to zero, 'remove': remove, 'keep': with full capacity
+
+links:
+  p_max_pu: 1.0
+  p_nom_max: .inf
+  under_construction: "zero" # 'zero': set capacity to zero, 'remove': remove, 'keep': with full capacity
+
+transformers:
+  x: 0.1
+  s_nom: 2000.
+  type: ""
+
+atlite:
+  nprocesses: 4
+  cutouts:
+    # geographical bounds automatically determined from countries input
+    cutout-2013-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
+      # The cutout time is automatically set by the snapshot range. See `snapshot:` option above and 'build_cutout.py'.
+      # time: ["2013-01-01", "2014-01-01"]  # to manually specify a different weather year (~70 years available)
+      # The cutout spatial extent [x,y] is automatically set by country selection. See `countires:` option above and 'build_cutout.py'.
+      # x: [-12., 35.]  # set cutout range manual, instead of automatic by boundaries of country
+      # y: [33., 72]    # manual set cutout range
+
+
+renewable:
+  onwind:
+    cutout: cutout-2013-era5
+    resource:
+      method: wind
+      turbine: Vestas_V112_3MW
+    capacity_per_sqkm: 3 # conservative, ScholzPhd Tab 4.3.1: 10MW/km^2
+    # correction_factor: 0.93
+    copernicus:
+      # Scholz, Y. (2012). Renewable energy based electricity supply at low costs:
+      #  development of the REMix model and application for Europe. ( p.42 / p.28)
+      # CLC grid codes:
+      # 11X/12X - Various forest types
+      # 20  - Shrubs
+      # 30  - Herbaceus vegetation
+      # 40  - Cropland
+      # 50  - Urban
+      # 60  - Bare / Sparse vegetation
+      # 80  - Permanent water bodies
+      # 100 - Moss and lichen
+      # 200 - Open sea
+      grid_codes: [20, 30, 40, 60, 100, 111, 112, 113, 114, 115, 116, 121, 122, 123, 124, 125, 126]
+      distance: 1000
+      distance_grid_codes: [50]
+    natura: true
+    potential: simple # or conservative
+    clip_p_max_pu: 1.e-2
+    extendable: true
+  offwind-ac:
+    cutout: cutout-2013-era5
+    resource:
+      method: wind
+      turbine: NREL_ReferenceTurbine_5MW_offshore
+    capacity_per_sqkm: 2
+    correction_factor: 0.8855
+    # proxy for wake losses
+    # from 10.1016/j.energy.2018.08.153
+    # until done more rigorously in #153
+    copernicus:
+      grid_codes: [80, 200]
+    natura: true
+    max_depth: 50
+    max_shore_distance: 30000
+    potential: simple # or conservative
+    clip_p_max_pu: 1.e-2
+    extendable: true
+  offwind-dc:
+    cutout: cutout-2013-era5
+    resource:
+      method: wind
+      turbine: NREL_ReferenceTurbine_5MW_offshore
+    # ScholzPhd Tab 4.3.1: 10MW/km^2
+    capacity_per_sqkm: 3
+    correction_factor: 0.8855
+    # proxy for wake losses
+    # from 10.1016/j.energy.2018.08.153
+    # until done more rigorously in #153
+    copernicus:
+      grid_codes: [80, 200]
+    natura: true
+    max_depth: 50
+    min_shore_distance: 30000
+    potential: simple # or conservative
+    clip_p_max_pu: 1.e-2
+    extendable: true
+  solar:
+    cutout: cutout-2013-era5
+    resource:
+      method: pv
+      panel: CSi
+      orientation: latitude_optimal # will lead into optimal design
+        # slope: 0.  # slope: 0 represent a flat panel
+        # azimuth: 180.  # azimuth: 180 south orientation
+    capacity_per_sqkm: 4.6 # From 1.7 to 4.6 addresses issue #361
+    # Determined by comparing uncorrected area-weighted full-load hours to those
+    # published in Supplementary Data to
+    # Pietzcker, Robert Carl, et al. "Using the sun to decarbonize the power
+    # sector: The economic potential of photovoltaics and concentrating solar
+    # power." Applied Energy 135 (2014): 704-720.
+    correction_factor: 0.854337
+    copernicus:
+      grid_codes: [20, 30, 40, 50, 60, 90, 100]
+    natura: true
+    potential: simple # or conservative
+    clip_p_max_pu: 1.e-2
+    extendable: true
+  hydro:
+    cutout: cutout-2013-era5
+    hydrobasins_level: 6
+    resource:
+      method: hydro
+      hydrobasins: data/hydrobasins/hybas_world.shp
+      flowspeed: 1.0  # m/s
+      # weight_with_height: false
+      # show_progress: true
+    carriers: [ror, PHS, hydro]
+    PHS_max_hours: 6
+    hydro_max_hours: "energy_capacity_totals_by_country"  # not active
+    hydro_max_hours_default: 6.0  # (optional, default 6) Default value of max_hours for hydro when NaN values are found
+    clip_min_inflow: 1.0
+    extendable: true
+    normalization:
+      method: eia  # 'hydro_capacities' to rescale country hydro production by using hydro_capacities, 'eia' to rescale by eia data, false for no rescaling
+      year: 2020  # (optional) year of statistics used to rescale the runoff time series. When not provided, the weather year of the snapshots is used
+    multiplier: 1.1  # multiplier applied after the normalization of the hydro production; default 1.0
+  csp:
+    cutout: cutout-2013-era5
+    resource:
+      method: csp
+      installation: SAM_solar_tower
+    capacity_per_sqkm: 2.392 # From 1.7 to 4.6 addresses issue #361
+    # Determined by comparing uncorrected area-weighted full-load hours to those
+    # published in Supplementary Data to
+    # Pietzcker, Robert Carl, et al. "Using the sun to decarbonize the power
+    # sector: The economic potential of photovoltaics and concentrating solar
+    # power." Applied Energy 135 (2014): 704-720.
+    copernicus:
+      grid_codes: [20, 30, 40, 60, 90]
+      distancing_codes: [50]
+      distance_to_codes: 3000
+    natura: true
+    potential: simple # or conservative
+    clip_p_max_pu: 1.e-2
+    extendable: true
+    csp_model: advanced # simple or advanced
+
+# TODO: Needs to be adjusted for Africa.
+# Costs Configuration (Do not remove, needed for Sphynx documentation).
+costs:
+  year: 2035
+  version: v0.9.2
+  rooftop_share: 0.14  # based on the potentials, assuming  (0.1 kW/m2 and 10 m2/person)
+  USD2013_to_EUR2013: 0.7532 # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html
+  fill_values:
+    FOM: 0
+    VOM: 0
+    efficiency: 1
+    fuel: 0
+    investment: 0
+    lifetime: 25
+    CO2 intensity: 0
+    discount rate: 0.06
+  marginal_cost: # EUR/MWh
+    solar: 0.01
+    onwind: 0.015
+    offwind: 0.015
+    hydro: 0.
+    H2: 0.
+    electrolysis: 0.
+    fuel cell: 0.
+    battery: 0.
+    battery inverter: 0.
+  emission_prices: # in currency per tonne emission, only used with the option Ep
+    co2: 0.
+
+
+monte_carlo:
+  # Description: Specify Monte Carlo sampling options for uncertainty analysis.
+  # Define the option list for Monte Carlo sampling.
+  # Make sure add_to_snakefile is set to true to enable Monte-Carlo
+  options:
+    add_to_snakefile: false # When set to true, enables Monte Carlo sampling
+    samples: 9 # number of optimizations. Note that number of samples when using scipy has to be the square of a prime number
+    sampling_strategy: "chaospy"  # "pydoe2", "chaospy", "scipy", packages that are supported
+    seed: 42 # set seedling for reproducibilty
+  # Uncertanties on any PyPSA object are specified by declaring the specific PyPSA object under the key 'uncertainties'.
+  # For each PyPSA object, the 'type' and 'args' keys represent the type of distribution and its argument, respectively.
+  # Supported distributions types are uniform, normal, lognormal, triangle, beta and gamma.
+  # The arguments of the distribution are passed using the key 'args'  as follows, tailored by distribution type
+  # normal: [mean, std], lognormal: [mean, std], uniform: [lower_bound, upper_bound],
+  # triangle: [mid_point (between 0 - 1)], beta: [alpha, beta], gamma: [shape, scale]
+  # More info on the distributions are documented in the Chaospy reference guide...
+  # https://chaospy.readthedocs.io/en/master/reference/distribution/index.html
+  # An abstract example is as follows:
+  # {pypsa network object, e.g. "loads_t.p_set"}:
+  # type: {any supported distribution among the previous: "uniform", "normal", ...}
+  # args: {arguments passed as a list depending on the distribution, see the above and more at https://pypsa.readthedocs.io/}
+  uncertainties:
+    loads_t.p_set:
+      type: uniform
+      args: [0, 1]
+    generators_t.p_max_pu.loc[:, n.generators.carrier == "onwind"]:
+      type: lognormal
+      args: [1.5]
+    generators_t.p_max_pu.loc[:, n.generators.carrier == "solar"]:
+      type: beta
+      args: [0.5, 2]
+
+
+
+solving:
+  options:
+    formulation: kirchhoff
+    load_shedding: true
+    noisy_costs: true
+    min_iterations: 4
+    max_iterations: 6
+    clip_p_max_pu: 0.01
+    skip_iterations: true
+    track_iterations: false
+    #nhours: 10
+  solver:
+    name: gurobi
+    threads: 4
+    method: 2 # barrier (=ipm)
+    crossover: 0
+    BarConvTol: 1.e-5
+    FeasibilityTol: 1.e-6
+    AggFill: 0
+    PreDual: 0
+    GURO_PAR_BARDENSETHRESH: 200
+
+
+plotting:
+  map:
+    figsize: [7, 7]
+    boundaries: [-10.2, 29, 35, 72]
+    p_nom:
+      bus_size_factor: 5.e+4
+      linewidth_factor: 3.e+3
+
+  costs_max: 800
+  costs_threshold: 1
+
+  energy_max: 15000.
+  energy_min: -10000.
+  energy_threshold: 50.
+
+  vre_techs: ["onwind", "offwind-ac", "offwind-dc", "solar", "ror"]
+  conv_techs: ["OCGT", "CCGT", "nuclear", "coal", "oil"]
+  storage_techs: ["hydro+PHS", "battery", "H2"]
+  load_carriers: ["AC load"]
+  AC_carriers: ["AC line", "AC transformer"]
+  link_carriers: ["DC line", "Converter AC-DC"]
+  tech_colors:
+    "onwind": "#235ebc"
+    "onshore wind": "#235ebc"
+    "offwind": "#6895dd"
+    "offwind-ac": "#6895dd"
+    "offshore wind": "#6895dd"
+    "offshore wind ac": "#6895dd"
+    "offwind-dc": "#74c6f2"
+    "offshore wind dc": "#74c6f2"
+    "hydro": "#08ad97"
+    "hydro+PHS": "#08ad97"
+    "PHS": "#08ad97"
+    "hydro reservoir": "#08ad97"
+    "hydroelectricity": "#08ad97"
+    "ror": "#4adbc8"
+    "run of river": "#4adbc8"
+    "solar": "#f9d002"
+    "solar PV": "#f9d002"
+    "solar thermal": "#ffef60"
+    "biomass": "#0c6013"
+    "solid biomass": "#06540d"
+    "biogas": "#23932d"
+    "waste": "#68896b"
+    "geothermal": "#ba91b1"
+    "OCGT": "#d35050"
+    "gas": "#d35050"
+    "natural gas": "#d35050"
+    "CCGT": "#b20101"
+    "nuclear": "#ff9000"
+    "coal": "#707070"
+    "lignite": "#9e5a01"
+    "oil": "#262626"
+    "H2": "#ea048a"
+    "hydrogen storage": "#ea048a"
+    "battery": "#b8ea04"
+    "Electric load": "#f9d002"
+    "electricity": "#f9d002"
+    "lines": "#70af1d"
+    "transmission lines": "#70af1d"
+    "AC": "#70af1d"
+    "AC-AC": "#70af1d"
+    "AC line": "#70af1d"
+    "links": "#8a1caf"
+    "HVDC links": "#8a1caf"
+    "DC": "#8a1caf"
+    "DC-DC": "#8a1caf"
+    "DC link": "#8a1caf"
+    "load": "#ff0000"
+    "load shedding": "#ff0000"
+    "battery discharger": slategray
+    "battery charger": slategray
+    "h2 fuel cell": '#c251ae'
+    "h2 electrolysis": '#ff29d9'
+    "csp": "#fdd404"
+  nice_names:
+    OCGT: "Open-Cycle Gas"
+    CCGT: "Combined-Cycle Gas"
+    offwind-ac: "Offshore Wind (AC)"
+    offwind-dc: "Offshore Wind (DC)"
+    onwind: "Onshore Wind"
+    solar: "Solar"
+    PHS: "Pumped Hydro Storage"
+    hydro: "Reservoir & Dam"
+    battery: "Battery Storage"
+    H2: "Hydrogen Storage"
+    lines: "Transmission Lines"
+    ror: "Run of River"

--- a/config.pypsa-earth_med.yaml
+++ b/config.pypsa-earth_med.yaml
@@ -1,0 +1,511 @@
+# SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
+#
+# SPDX-License-Identifier: CC0-1.0
+
+version: 0.4.0
+tutorial: false
+
+logging:
+  level: INFO
+  format: "%(levelname)s:%(name)s:%(message)s"
+
+countries: ["BR"]
+# Can be replaced by country ["NG", "BJ"], continent ["Africa"] or user-specific region, see more at https://pypsa-earth.readthedocs.io/en/latest/configuration.html#top-level-configuration
+
+enable:
+  retrieve_databundle: true  #  Recommended 'true', for the first run. Otherwise data might be missing.
+  retrieve_cost_data: true  # true: retrieves cost data from technology data and saves in resources/costs.csv, false: uses cost data in data/costs.csv
+  download_osm_data: true  # If 'true', OpenStreetMap data will be downloaded for the above given countries
+  build_natura_raster: false  # If True, then an exclusion raster will be build
+  build_cutout: false
+  # If "build_cutout" : true, then environmental data is extracted according to `snapshots` date range and `countries`
+  # requires cds API key https://cds.climate.copernicus.eu/api-how-to
+  # More information https://atlite.readthedocs.io/en/latest/introduction.html#datasets
+
+custom_rules: []  # Default empty [] or link to custom rule file e.g. ["my_folder/my_rules.smk"] that add rules to Snakefile
+
+run:
+  name: "" # use this to keep track of runs with different settings
+  shared_cutouts: true  # set to true to share the default cutout(s) across runs
+                        # Note: value false requires build_cutout to be enabled
+
+scenario:
+  simpl: ['']
+  ll: ['copt']
+  clusters: [10]
+  opts: [Co2L-3H]
+
+snapshots:
+  start: "2013-01-01"
+  end: "2014-01-01"
+  inclusive: "left" # end is not inclusive
+
+# definition of the Coordinate Reference Systems
+crs:
+  geo_crs: EPSG:4326  # general geographic projection, not used for metric measures. "EPSG:4326" is the standard used by OSM and google maps
+  distance_crs: EPSG:3857  # projection for distance measurements only. Possible recommended values are "EPSG:3857" (used by OSM and Google Maps)
+  area_crs: ESRI:54009  # projection for area measurements only. Possible recommended values are Global Mollweide "ESRI:54009"
+
+# download_osm_data_nprocesses: 10  # (optional) number of threads used to download osm data
+
+augmented_line_connection:
+  add_to_snakefile: false  # If True, includes this rule to the workflow
+  connectivity_upgrade: 2  # Min. lines connection per node, https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation.html#networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation
+  new_line_type: ["HVAC"]  # Expanded lines can be either ["HVAC"] or ["HVDC"] or both ["HVAC", "HVDC"]
+  min_expansion: 1  # [MW] New created line expands by float/int input
+  min_DC_length: 600  # [km] Minimum line length of DC line
+
+cluster_options:
+  simplify_network:
+    to_substations: false # network is simplified to nodes with positive or negative power injection (i.e. substations or offwind connections)
+    algorithm: kmeans # choose from: [hac, kmeans]
+    feature: solar+onwind-time # only for hac. choose from: [solar+onwind-time, solar+onwind-cap, solar-time, solar-cap, solar+offwind-cap] etc.
+    exclude_carriers: []
+    remove_stubs: false
+    remove_stubs_across_borders: true
+    p_threshold_drop_isolated: 20 # [MW] isolated buses are being discarded if bus mean power is below the specified threshold
+    p_threshold_merge_isolated: 300 # [MW] isolated buses are being merged into a single isolated bus if a bus mean power is below the specified threshold
+    s_threshold_fetch_isolated: 0.05 # [-] a share of the national load for merging an isolated network into a backbone network
+  cluster_network:
+    algorithm: kmeans
+    feature: solar+onwind-time
+    exclude_carriers: []
+  alternative_clustering: true  # "False" use Voronoi shapes, "True" use GADM shapes
+  distribute_cluster: ['load'] # Distributes cluster nodes per country according to ['load'],['pop'] or ['gdp']
+  out_logging: true  # When "True", logging is printed to console
+  aggregation_strategies:
+    generators:  # use "min" for more conservative assumptions
+      p_nom: sum
+      p_nom_max: sum
+      p_nom_min: sum
+      p_min_pu: mean
+      marginal_cost: mean
+      committable: any
+      ramp_limit_up: max
+      ramp_limit_down: max
+      efficiency: mean
+
+build_shape_options:
+  gadm_layer_id: 1  # GADM level area used for the gadm_shapes. Codes are country-dependent but roughly: 0: country, 1: region/county-like, 2: municipality-like
+  update_file: false  # When true, all the input files are downloaded again and replace the existing files
+  out_logging: true  # When true, logging is printed to console
+  year: 2020  # reference year used to derive shapes, info on population and info on GDP
+  nprocesses: 1  # number of processes to be used in build_shapes
+  worldpop_method: "standard"  # "standard" pulls from web 1kmx1km raster, "api" pulls from API 100mx100m raster, false (not "false") no pop addition to shape which is useful when generating only cutout
+  gdp_method: "standard"  # "standard" pulls from web 1x1km raster, false (not "false") no gdp addition to shape which useful when generating only cutout
+  contended_flag: "set_by_country" # "set_by_country" assigns the contended areas to the countries according to the GADM database, "drop" drops these contended areas from the model
+
+clean_osm_data_options:  # osm = OpenStreetMap
+  names_by_shapes: true  # Set the country name based on the extended country shapes
+  threshold_voltage: 51000  # [V] assets below that voltage threshold will not be used (cable, line, generator, etc.)
+  tag_substation: "transmission"  # Filters only substations with 'transmission' tag, ('distribution' also available)
+  add_line_endings: true  # When "True", then line endings are added to the dataset of the substations
+  generator_name_method: OSM  # Methodology to specify the name to the generator. Options: OSM (name as by OSM dataset), closest_city (name by the closest city)
+  use_custom_lines: "OSM_only"  # Use OSM (OSM_only), customized (custom_only), or both data sets (add_custom)
+  path_custom_lines: false  # If exists, provide the specific absolute path of the custom file e.g. (...\data\custom_lines.geojson)
+  use_custom_substations: "OSM_only"  # Use OSM (OSM_only), customized (custom_only), or both data sets (add_custom)
+  path_custom_substations: false  # If exists, provide the specific absolute path of the custom file e.g. (...\data\custom_substations.geojson)
+  use_custom_cables: "OSM_only"  # Use OSM (OSM_only), customized (custom_only), or both data sets (add_custom)
+  path_custom_cables: false  # If exists, provide the specific absolute path of the custom file e.g. (...\data\custom_cables.geojson)
+
+build_osm_network:  # Options of the build_osm_network script; osm = OpenStreetMap
+  group_close_buses: true  # When "True", close buses are merged and guarantee the voltage matching among line endings
+  group_tolerance_buses: 5000  # [m] (default 5000) Tolerance in meters of the close buses to merge
+  split_overpassing_lines: true  # When True, lines overpassing buses are splitted and connected to the bueses
+  overpassing_lines_tolerance: 1  # [m] (default 1) Tolerance to identify lines overpassing buses
+  force_ac: true  # When true, it forces all components (lines and substation) to be AC-only. To be used if DC assets create problem.
+
+base_network:
+  min_voltage_substation_offshore: 51000  # [V] minimum voltage of the offshore substations
+  min_voltage_rebase_voltage: 51000  # [V] minimum voltage in base network
+
+load_options:
+  ssp: "ssp2-2.6" # shared socio-economic pathway (GDP and population growth) scenario to consider
+  weather_year: 2013  # Load scenarios available with different weather year (different renewable potentials)
+  prediction_year: 2030  # Load scenarios available with different prediction year (GDP, population)
+  scale: 1  # scales all load time-series, i.e. 2 = doubles load
+
+electricity:
+  base_voltage: 380.
+  voltages: [132., 220., 300., 380., 500., 750.]
+  co2limit: 274.0e+6  # European default, 0.05 * 3.1e9*0.5, needs to be adjusted for Africa
+  co2base: 1.487e+9  # European default, adjustment to Africa necessary
+  agg_p_nom_limits: data/agg_p_nom_minmax.csv
+  hvdc_as_lines: false  # should HVDC lines be modeled as `Line` or as `Link` component?
+  automatic_emission: false
+  automatic_emission_base_year: 1990 # 1990 is taken as default. Any year from 1970 to 2018 can be selected.
+
+  operational_reserve: # like https://genxproject.github.io/GenX/dev/core/#Reserves
+    activate: false
+    epsilon_load: 0.02 # share of total load
+    epsilon_vres: 0.02 # share of total renewable supply
+    contingency: 0 # fixed capacity in MW
+
+  max_hours:
+    battery: 6
+    H2: 168
+
+  extendable_carriers:
+    Generator: [solar, onwind, offwind-ac, offwind-dc, OCGT]
+    StorageUnit: []  # battery, H2
+    Store: [] #battery, H2]
+    Link: []  # H2 pipeline
+
+  powerplants_filter: (DateOut >= 2022 or DateOut != DateOut)
+  custom_powerplants: false  #  "false" use only powerplantmatching (ppm) data, "merge" combines ppm and custom powerplants, "replace" use only custom powerplants
+
+  conventional_carriers: [nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass]
+  renewable_carriers: [solar, onwind, csp, offwind-ac, offwind-dc, hydro]
+
+  estimate_renewable_capacities:
+    stats: 'irena' # False, = greenfield expansion, 'irena' uses IRENA stats to add expansion limits
+    year: 2023  # Reference year, available years for IRENA stats are 2000 to 2023
+    p_nom_min: 1  # any float, scales the minimum expansion acquired from stats, i.e. 110% of <years>'s capacities => p_nom_min: 1.1
+    p_nom_max: false  # sets the expansion constraint, False to deactivate this option and use estimated renewable potentials determine by the workflow, float scales the p_nom_min factor accordingly
+    technology_mapping:
+      # Wind is the Fueltype in ppm.data.Capacity_stats, onwind, offwind-{ac,dc} the carrier in PyPSA-Earth
+      Offshore: [offwind-ac, offwind-dc]
+      Onshore: [onwind]
+      PV: [solar]
+
+lines:
+  ac_types:
+    132.: "243-AL1/39-ST1A 20.0"
+    220.: "Al/St 240/40 2-bundle 220.0"
+    300.: "Al/St 240/40 3-bundle 300.0"
+    380.: "Al/St 240/40 4-bundle 380.0"
+    500.: "Al/St 240/40 4-bundle 380.0"
+    750.: "Al/St 560/50 4-bundle 750.0"
+  dc_types:
+    500.: "HVDC XLPE 1000"
+  s_max_pu: 0.7
+  s_nom_max: .inf
+  length_factor: 1.25
+  under_construction: "zero" # 'zero': set capacity to zero, 'remove': remove, 'keep': with full capacity
+
+links:
+  p_max_pu: 1.0
+  p_nom_max: .inf
+  under_construction: "zero" # 'zero': set capacity to zero, 'remove': remove, 'keep': with full capacity
+
+transformers:
+  x: 0.1
+  s_nom: 2000.
+  type: ""
+
+atlite:
+  nprocesses: 4
+  cutouts:
+    # geographical bounds automatically determined from countries input
+    cutout-2013-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
+      # The cutout time is automatically set by the snapshot range. See `snapshot:` option above and 'build_cutout.py'.
+      # time: ["2013-01-01", "2014-01-01"]  # to manually specify a different weather year (~70 years available)
+      # The cutout spatial extent [x,y] is automatically set by country selection. See `countires:` option above and 'build_cutout.py'.
+      # x: [-12., 35.]  # set cutout range manual, instead of automatic by boundaries of country
+      # y: [33., 72]    # manual set cutout range
+
+
+renewable:
+  onwind:
+    cutout: cutout-2013-era5
+    resource:
+      method: wind
+      turbine: Vestas_V112_3MW
+    capacity_per_sqkm: 3 # conservative, ScholzPhd Tab 4.3.1: 10MW/km^2
+    # correction_factor: 0.93
+    copernicus:
+      # Scholz, Y. (2012). Renewable energy based electricity supply at low costs:
+      #  development of the REMix model and application for Europe. ( p.42 / p.28)
+      # CLC grid codes:
+      # 11X/12X - Various forest types
+      # 20  - Shrubs
+      # 30  - Herbaceus vegetation
+      # 40  - Cropland
+      # 50  - Urban
+      # 60  - Bare / Sparse vegetation
+      # 80  - Permanent water bodies
+      # 100 - Moss and lichen
+      # 200 - Open sea
+      grid_codes: [20, 30, 40, 60, 100, 111, 112, 113, 114, 115, 116, 121, 122, 123, 124, 125, 126]
+      distance: 1000
+      distance_grid_codes: [50]
+    natura: true
+    potential: simple # or conservative
+    clip_p_max_pu: 1.e-2
+    extendable: true
+  offwind-ac:
+    cutout: cutout-2013-era5
+    resource:
+      method: wind
+      turbine: NREL_ReferenceTurbine_5MW_offshore
+    capacity_per_sqkm: 2
+    correction_factor: 0.8855
+    # proxy for wake losses
+    # from 10.1016/j.energy.2018.08.153
+    # until done more rigorously in #153
+    copernicus:
+      grid_codes: [80, 200]
+    natura: true
+    max_depth: 50
+    max_shore_distance: 30000
+    potential: simple # or conservative
+    clip_p_max_pu: 1.e-2
+    extendable: true
+  offwind-dc:
+    cutout: cutout-2013-era5
+    resource:
+      method: wind
+      turbine: NREL_ReferenceTurbine_5MW_offshore
+    # ScholzPhd Tab 4.3.1: 10MW/km^2
+    capacity_per_sqkm: 3
+    correction_factor: 0.8855
+    # proxy for wake losses
+    # from 10.1016/j.energy.2018.08.153
+    # until done more rigorously in #153
+    copernicus:
+      grid_codes: [80, 200]
+    natura: true
+    max_depth: 50
+    min_shore_distance: 30000
+    potential: simple # or conservative
+    clip_p_max_pu: 1.e-2
+    extendable: true
+  solar:
+    cutout: cutout-2013-era5
+    resource:
+      method: pv
+      panel: CSi
+      orientation: latitude_optimal # will lead into optimal design
+        # slope: 0.  # slope: 0 represent a flat panel
+        # azimuth: 180.  # azimuth: 180 south orientation
+    capacity_per_sqkm: 4.6 # From 1.7 to 4.6 addresses issue #361
+    # Determined by comparing uncorrected area-weighted full-load hours to those
+    # published in Supplementary Data to
+    # Pietzcker, Robert Carl, et al. "Using the sun to decarbonize the power
+    # sector: The economic potential of photovoltaics and concentrating solar
+    # power." Applied Energy 135 (2014): 704-720.
+    correction_factor: 0.854337
+    copernicus:
+      grid_codes: [20, 30, 40, 50, 60, 90, 100]
+    natura: true
+    potential: simple # or conservative
+    clip_p_max_pu: 1.e-2
+    extendable: true
+  hydro:
+    cutout: cutout-2013-era5
+    hydrobasins_level: 6
+    resource:
+      method: hydro
+      hydrobasins: data/hydrobasins/hybas_world.shp
+      flowspeed: 1.0  # m/s
+      # weight_with_height: false
+      # show_progress: true
+    carriers: [ror, PHS, hydro]
+    PHS_max_hours: 6
+    hydro_max_hours: "energy_capacity_totals_by_country"  # not active
+    hydro_max_hours_default: 6.0  # (optional, default 6) Default value of max_hours for hydro when NaN values are found
+    clip_min_inflow: 1.0
+    extendable: true
+    normalization:
+      method: eia  # 'hydro_capacities' to rescale country hydro production by using hydro_capacities, 'eia' to rescale by eia data, false for no rescaling
+      year: 2020  # (optional) year of statistics used to rescale the runoff time series. When not provided, the weather year of the snapshots is used
+    multiplier: 1.1  # multiplier applied after the normalization of the hydro production; default 1.0
+  csp:
+    cutout: cutout-2013-era5
+    resource:
+      method: csp
+      installation: SAM_solar_tower
+    capacity_per_sqkm: 2.392 # From 1.7 to 4.6 addresses issue #361
+    # Determined by comparing uncorrected area-weighted full-load hours to those
+    # published in Supplementary Data to
+    # Pietzcker, Robert Carl, et al. "Using the sun to decarbonize the power
+    # sector: The economic potential of photovoltaics and concentrating solar
+    # power." Applied Energy 135 (2014): 704-720.
+    copernicus:
+      grid_codes: [20, 30, 40, 60, 90]
+      distancing_codes: [50]
+      distance_to_codes: 3000
+    natura: true
+    potential: simple # or conservative
+    clip_p_max_pu: 1.e-2
+    extendable: true
+    csp_model: advanced # simple or advanced
+
+# TODO: Needs to be adjusted for Africa.
+# Costs Configuration (Do not remove, needed for Sphynx documentation).
+costs:
+  year: 2035
+  version: v0.9.2
+  rooftop_share: 0.14  # based on the potentials, assuming  (0.1 kW/m2 and 10 m2/person)
+  USD2013_to_EUR2013: 0.7532 # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html
+  fill_values:
+    FOM: 0
+    VOM: 0
+    efficiency: 1
+    fuel: 0
+    investment: 0
+    lifetime: 25
+    CO2 intensity: 0
+    discount rate: 0.08
+  marginal_cost: # EUR/MWh
+    solar: 0.01
+    onwind: 0.015
+    offwind: 0.015
+    hydro: 0.
+    H2: 0.
+    electrolysis: 0.
+    fuel cell: 0.
+    battery: 0.
+    battery inverter: 0.
+  emission_prices: # in currency per tonne emission, only used with the option Ep
+    co2: 0.
+
+
+monte_carlo:
+  # Description: Specify Monte Carlo sampling options for uncertainty analysis.
+  # Define the option list for Monte Carlo sampling.
+  # Make sure add_to_snakefile is set to true to enable Monte-Carlo
+  options:
+    add_to_snakefile: false # When set to true, enables Monte Carlo sampling
+    samples: 9 # number of optimizations. Note that number of samples when using scipy has to be the square of a prime number
+    sampling_strategy: "chaospy"  # "pydoe2", "chaospy", "scipy", packages that are supported
+    seed: 42 # set seedling for reproducibilty
+  # Uncertanties on any PyPSA object are specified by declaring the specific PyPSA object under the key 'uncertainties'.
+  # For each PyPSA object, the 'type' and 'args' keys represent the type of distribution and its argument, respectively.
+  # Supported distributions types are uniform, normal, lognormal, triangle, beta and gamma.
+  # The arguments of the distribution are passed using the key 'args'  as follows, tailored by distribution type
+  # normal: [mean, std], lognormal: [mean, std], uniform: [lower_bound, upper_bound],
+  # triangle: [mid_point (between 0 - 1)], beta: [alpha, beta], gamma: [shape, scale]
+  # More info on the distributions are documented in the Chaospy reference guide...
+  # https://chaospy.readthedocs.io/en/master/reference/distribution/index.html
+  # An abstract example is as follows:
+  # {pypsa network object, e.g. "loads_t.p_set"}:
+  # type: {any supported distribution among the previous: "uniform", "normal", ...}
+  # args: {arguments passed as a list depending on the distribution, see the above and more at https://pypsa.readthedocs.io/}
+  uncertainties:
+    loads_t.p_set:
+      type: uniform
+      args: [0, 1]
+    generators_t.p_max_pu.loc[:, n.generators.carrier == "onwind"]:
+      type: lognormal
+      args: [1.5]
+    generators_t.p_max_pu.loc[:, n.generators.carrier == "solar"]:
+      type: beta
+      args: [0.5, 2]
+
+
+
+solving:
+  options:
+    formulation: kirchhoff
+    load_shedding: true
+    noisy_costs: true
+    min_iterations: 4
+    max_iterations: 6
+    clip_p_max_pu: 0.01
+    skip_iterations: true
+    track_iterations: false
+    #nhours: 10
+  solver:
+    name: gurobi
+    threads: 4
+    method: 2 # barrier (=ipm)
+    crossover: 0
+    BarConvTol: 1.e-5
+    FeasibilityTol: 1.e-6
+    AggFill: 0
+    PreDual: 0
+    GURO_PAR_BARDENSETHRESH: 200
+
+
+plotting:
+  map:
+    figsize: [7, 7]
+    boundaries: [-10.2, 29, 35, 72]
+    p_nom:
+      bus_size_factor: 5.e+4
+      linewidth_factor: 3.e+3
+
+  costs_max: 800
+  costs_threshold: 1
+
+  energy_max: 15000.
+  energy_min: -10000.
+  energy_threshold: 50.
+
+  vre_techs: ["onwind", "offwind-ac", "offwind-dc", "solar", "ror"]
+  conv_techs: ["OCGT", "CCGT", "nuclear", "coal", "oil"]
+  storage_techs: ["hydro+PHS", "battery", "H2"]
+  load_carriers: ["AC load"]
+  AC_carriers: ["AC line", "AC transformer"]
+  link_carriers: ["DC line", "Converter AC-DC"]
+  tech_colors:
+    "onwind": "#235ebc"
+    "onshore wind": "#235ebc"
+    "offwind": "#6895dd"
+    "offwind-ac": "#6895dd"
+    "offshore wind": "#6895dd"
+    "offshore wind ac": "#6895dd"
+    "offwind-dc": "#74c6f2"
+    "offshore wind dc": "#74c6f2"
+    "hydro": "#08ad97"
+    "hydro+PHS": "#08ad97"
+    "PHS": "#08ad97"
+    "hydro reservoir": "#08ad97"
+    "hydroelectricity": "#08ad97"
+    "ror": "#4adbc8"
+    "run of river": "#4adbc8"
+    "solar": "#f9d002"
+    "solar PV": "#f9d002"
+    "solar thermal": "#ffef60"
+    "biomass": "#0c6013"
+    "solid biomass": "#06540d"
+    "biogas": "#23932d"
+    "waste": "#68896b"
+    "geothermal": "#ba91b1"
+    "OCGT": "#d35050"
+    "gas": "#d35050"
+    "natural gas": "#d35050"
+    "CCGT": "#b20101"
+    "nuclear": "#ff9000"
+    "coal": "#707070"
+    "lignite": "#9e5a01"
+    "oil": "#262626"
+    "H2": "#ea048a"
+    "hydrogen storage": "#ea048a"
+    "battery": "#b8ea04"
+    "Electric load": "#f9d002"
+    "electricity": "#f9d002"
+    "lines": "#70af1d"
+    "transmission lines": "#70af1d"
+    "AC": "#70af1d"
+    "AC-AC": "#70af1d"
+    "AC line": "#70af1d"
+    "links": "#8a1caf"
+    "HVDC links": "#8a1caf"
+    "DC": "#8a1caf"
+    "DC-DC": "#8a1caf"
+    "DC link": "#8a1caf"
+    "load": "#ff0000"
+    "load shedding": "#ff0000"
+    "battery discharger": slategray
+    "battery charger": slategray
+    "h2 fuel cell": '#c251ae'
+    "h2 electrolysis": '#ff29d9'
+    "csp": "#fdd404"
+  nice_names:
+    OCGT: "Open-Cycle Gas"
+    CCGT: "Combined-Cycle Gas"
+    offwind-ac: "Offshore Wind (AC)"
+    offwind-dc: "Offshore Wind (DC)"
+    onwind: "Onshore Wind"
+    solar: "Solar"
+    PHS: "Pumped Hydro Storage"
+    hydro: "Reservoir & Dam"
+    battery: "Battery Storage"
+    H2: "Hydrogen Storage"
+    lines: "Transmission Lines"
+    ror: "Run of River"

--- a/config.pypsa-earth_vhigh.yaml
+++ b/config.pypsa-earth_vhigh.yaml
@@ -1,0 +1,511 @@
+# SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
+#
+# SPDX-License-Identifier: CC0-1.0
+
+version: 0.4.0
+tutorial: false
+
+logging:
+  level: INFO
+  format: "%(levelname)s:%(name)s:%(message)s"
+
+countries: ["BR"]
+# Can be replaced by country ["NG", "BJ"], continent ["Africa"] or user-specific region, see more at https://pypsa-earth.readthedocs.io/en/latest/configuration.html#top-level-configuration
+
+enable:
+  retrieve_databundle: true  #  Recommended 'true', for the first run. Otherwise data might be missing.
+  retrieve_cost_data: true  # true: retrieves cost data from technology data and saves in resources/costs.csv, false: uses cost data in data/costs.csv
+  download_osm_data: true  # If 'true', OpenStreetMap data will be downloaded for the above given countries
+  build_natura_raster: false  # If True, then an exclusion raster will be build
+  build_cutout: false
+  # If "build_cutout" : true, then environmental data is extracted according to `snapshots` date range and `countries`
+  # requires cds API key https://cds.climate.copernicus.eu/api-how-to
+  # More information https://atlite.readthedocs.io/en/latest/introduction.html#datasets
+
+custom_rules: []  # Default empty [] or link to custom rule file e.g. ["my_folder/my_rules.smk"] that add rules to Snakefile
+
+run:
+  name: "" # use this to keep track of runs with different settings
+  shared_cutouts: true  # set to true to share the default cutout(s) across runs
+                        # Note: value false requires build_cutout to be enabled
+
+scenario:
+  simpl: ['']
+  ll: ['copt']
+  clusters: [10]
+  opts: [Co2L-3H]
+
+snapshots:
+  start: "2013-01-01"
+  end: "2014-01-01"
+  inclusive: "left" # end is not inclusive
+
+# definition of the Coordinate Reference Systems
+crs:
+  geo_crs: EPSG:4326  # general geographic projection, not used for metric measures. "EPSG:4326" is the standard used by OSM and google maps
+  distance_crs: EPSG:3857  # projection for distance measurements only. Possible recommended values are "EPSG:3857" (used by OSM and Google Maps)
+  area_crs: ESRI:54009  # projection for area measurements only. Possible recommended values are Global Mollweide "ESRI:54009"
+
+# download_osm_data_nprocesses: 10  # (optional) number of threads used to download osm data
+
+augmented_line_connection:
+  add_to_snakefile: false  # If True, includes this rule to the workflow
+  connectivity_upgrade: 2  # Min. lines connection per node, https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation.html#networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation
+  new_line_type: ["HVAC"]  # Expanded lines can be either ["HVAC"] or ["HVDC"] or both ["HVAC", "HVDC"]
+  min_expansion: 1  # [MW] New created line expands by float/int input
+  min_DC_length: 600  # [km] Minimum line length of DC line
+
+cluster_options:
+  simplify_network:
+    to_substations: false # network is simplified to nodes with positive or negative power injection (i.e. substations or offwind connections)
+    algorithm: kmeans # choose from: [hac, kmeans]
+    feature: solar+onwind-time # only for hac. choose from: [solar+onwind-time, solar+onwind-cap, solar-time, solar-cap, solar+offwind-cap] etc.
+    exclude_carriers: []
+    remove_stubs: false
+    remove_stubs_across_borders: true
+    p_threshold_drop_isolated: 20 # [MW] isolated buses are being discarded if bus mean power is below the specified threshold
+    p_threshold_merge_isolated: 300 # [MW] isolated buses are being merged into a single isolated bus if a bus mean power is below the specified threshold
+    s_threshold_fetch_isolated: 0.05 # [-] a share of the national load for merging an isolated network into a backbone network
+  cluster_network:
+    algorithm: kmeans
+    feature: solar+onwind-time
+    exclude_carriers: []
+  alternative_clustering: true  # "False" use Voronoi shapes, "True" use GADM shapes
+  distribute_cluster: ['load'] # Distributes cluster nodes per country according to ['load'],['pop'] or ['gdp']
+  out_logging: true  # When "True", logging is printed to console
+  aggregation_strategies:
+    generators:  # use "min" for more conservative assumptions
+      p_nom: sum
+      p_nom_max: sum
+      p_nom_min: sum
+      p_min_pu: mean
+      marginal_cost: mean
+      committable: any
+      ramp_limit_up: max
+      ramp_limit_down: max
+      efficiency: mean
+
+build_shape_options:
+  gadm_layer_id: 1  # GADM level area used for the gadm_shapes. Codes are country-dependent but roughly: 0: country, 1: region/county-like, 2: municipality-like
+  update_file: false  # When true, all the input files are downloaded again and replace the existing files
+  out_logging: true  # When true, logging is printed to console
+  year: 2020  # reference year used to derive shapes, info on population and info on GDP
+  nprocesses: 1  # number of processes to be used in build_shapes
+  worldpop_method: "standard"  # "standard" pulls from web 1kmx1km raster, "api" pulls from API 100mx100m raster, false (not "false") no pop addition to shape which is useful when generating only cutout
+  gdp_method: "standard"  # "standard" pulls from web 1x1km raster, false (not "false") no gdp addition to shape which useful when generating only cutout
+  contended_flag: "set_by_country" # "set_by_country" assigns the contended areas to the countries according to the GADM database, "drop" drops these contended areas from the model
+
+clean_osm_data_options:  # osm = OpenStreetMap
+  names_by_shapes: true  # Set the country name based on the extended country shapes
+  threshold_voltage: 51000  # [V] assets below that voltage threshold will not be used (cable, line, generator, etc.)
+  tag_substation: "transmission"  # Filters only substations with 'transmission' tag, ('distribution' also available)
+  add_line_endings: true  # When "True", then line endings are added to the dataset of the substations
+  generator_name_method: OSM  # Methodology to specify the name to the generator. Options: OSM (name as by OSM dataset), closest_city (name by the closest city)
+  use_custom_lines: "OSM_only"  # Use OSM (OSM_only), customized (custom_only), or both data sets (add_custom)
+  path_custom_lines: false  # If exists, provide the specific absolute path of the custom file e.g. (...\data\custom_lines.geojson)
+  use_custom_substations: "OSM_only"  # Use OSM (OSM_only), customized (custom_only), or both data sets (add_custom)
+  path_custom_substations: false  # If exists, provide the specific absolute path of the custom file e.g. (...\data\custom_substations.geojson)
+  use_custom_cables: "OSM_only"  # Use OSM (OSM_only), customized (custom_only), or both data sets (add_custom)
+  path_custom_cables: false  # If exists, provide the specific absolute path of the custom file e.g. (...\data\custom_cables.geojson)
+
+build_osm_network:  # Options of the build_osm_network script; osm = OpenStreetMap
+  group_close_buses: true  # When "True", close buses are merged and guarantee the voltage matching among line endings
+  group_tolerance_buses: 5000  # [m] (default 5000) Tolerance in meters of the close buses to merge
+  split_overpassing_lines: true  # When True, lines overpassing buses are splitted and connected to the bueses
+  overpassing_lines_tolerance: 1  # [m] (default 1) Tolerance to identify lines overpassing buses
+  force_ac: true  # When true, it forces all components (lines and substation) to be AC-only. To be used if DC assets create problem.
+
+base_network:
+  min_voltage_substation_offshore: 51000  # [V] minimum voltage of the offshore substations
+  min_voltage_rebase_voltage: 51000  # [V] minimum voltage in base network
+
+load_options:
+  ssp: "ssp2-2.6" # shared socio-economic pathway (GDP and population growth) scenario to consider
+  weather_year: 2013  # Load scenarios available with different weather year (different renewable potentials)
+  prediction_year: 2030  # Load scenarios available with different prediction year (GDP, population)
+  scale: 1  # scales all load time-series, i.e. 2 = doubles load
+
+electricity:
+  base_voltage: 380.
+  voltages: [132., 220., 300., 380., 500., 750.]
+  co2limit: 274.0e+6  # European default, 0.05 * 3.1e9*0.5, needs to be adjusted for Africa
+  co2base: 1.487e+9  # European default, adjustment to Africa necessary
+  agg_p_nom_limits: data/agg_p_nom_minmax.csv
+  hvdc_as_lines: false  # should HVDC lines be modeled as `Line` or as `Link` component?
+  automatic_emission: false
+  automatic_emission_base_year: 1990 # 1990 is taken as default. Any year from 1970 to 2018 can be selected.
+
+  operational_reserve: # like https://genxproject.github.io/GenX/dev/core/#Reserves
+    activate: false
+    epsilon_load: 0.02 # share of total load
+    epsilon_vres: 0.02 # share of total renewable supply
+    contingency: 0 # fixed capacity in MW
+
+  max_hours:
+    battery: 6
+    H2: 168
+
+  extendable_carriers:
+    Generator: [solar, onwind, offwind-ac, offwind-dc, OCGT]
+    StorageUnit: []  # battery, H2
+    Store: [] #battery, H2]
+    Link: []  # H2 pipeline
+
+  powerplants_filter: (DateOut >= 2022 or DateOut != DateOut)
+  custom_powerplants: false  #  "false" use only powerplantmatching (ppm) data, "merge" combines ppm and custom powerplants, "replace" use only custom powerplants
+
+  conventional_carriers: [nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass]
+  renewable_carriers: [solar, onwind, csp, offwind-ac, offwind-dc, hydro]
+
+  estimate_renewable_capacities:
+    stats: 'irena' # False, = greenfield expansion, 'irena' uses IRENA stats to add expansion limits
+    year: 2023  # Reference year, available years for IRENA stats are 2000 to 2023
+    p_nom_min: 1  # any float, scales the minimum expansion acquired from stats, i.e. 110% of <years>'s capacities => p_nom_min: 1.1
+    p_nom_max: false  # sets the expansion constraint, False to deactivate this option and use estimated renewable potentials determine by the workflow, float scales the p_nom_min factor accordingly
+    technology_mapping:
+      # Wind is the Fueltype in ppm.data.Capacity_stats, onwind, offwind-{ac,dc} the carrier in PyPSA-Earth
+      Offshore: [offwind-ac, offwind-dc]
+      Onshore: [onwind]
+      PV: [solar]
+
+lines:
+  ac_types:
+    132.: "243-AL1/39-ST1A 20.0"
+    220.: "Al/St 240/40 2-bundle 220.0"
+    300.: "Al/St 240/40 3-bundle 300.0"
+    380.: "Al/St 240/40 4-bundle 380.0"
+    500.: "Al/St 240/40 4-bundle 380.0"
+    750.: "Al/St 560/50 4-bundle 750.0"
+  dc_types:
+    500.: "HVDC XLPE 1000"
+  s_max_pu: 0.7
+  s_nom_max: .inf
+  length_factor: 1.25
+  under_construction: "zero" # 'zero': set capacity to zero, 'remove': remove, 'keep': with full capacity
+
+links:
+  p_max_pu: 1.0
+  p_nom_max: .inf
+  under_construction: "zero" # 'zero': set capacity to zero, 'remove': remove, 'keep': with full capacity
+
+transformers:
+  x: 0.1
+  s_nom: 2000.
+  type: ""
+
+atlite:
+  nprocesses: 4
+  cutouts:
+    # geographical bounds automatically determined from countries input
+    cutout-2013-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
+      # The cutout time is automatically set by the snapshot range. See `snapshot:` option above and 'build_cutout.py'.
+      # time: ["2013-01-01", "2014-01-01"]  # to manually specify a different weather year (~70 years available)
+      # The cutout spatial extent [x,y] is automatically set by country selection. See `countires:` option above and 'build_cutout.py'.
+      # x: [-12., 35.]  # set cutout range manual, instead of automatic by boundaries of country
+      # y: [33., 72]    # manual set cutout range
+
+
+renewable:
+  onwind:
+    cutout: cutout-2013-era5
+    resource:
+      method: wind
+      turbine: Vestas_V112_3MW
+    capacity_per_sqkm: 3 # conservative, ScholzPhd Tab 4.3.1: 10MW/km^2
+    # correction_factor: 0.93
+    copernicus:
+      # Scholz, Y. (2012). Renewable energy based electricity supply at low costs:
+      #  development of the REMix model and application for Europe. ( p.42 / p.28)
+      # CLC grid codes:
+      # 11X/12X - Various forest types
+      # 20  - Shrubs
+      # 30  - Herbaceus vegetation
+      # 40  - Cropland
+      # 50  - Urban
+      # 60  - Bare / Sparse vegetation
+      # 80  - Permanent water bodies
+      # 100 - Moss and lichen
+      # 200 - Open sea
+      grid_codes: [20, 30, 40, 60, 100, 111, 112, 113, 114, 115, 116, 121, 122, 123, 124, 125, 126]
+      distance: 1000
+      distance_grid_codes: [50]
+    natura: true
+    potential: simple # or conservative
+    clip_p_max_pu: 1.e-2
+    extendable: true
+  offwind-ac:
+    cutout: cutout-2013-era5
+    resource:
+      method: wind
+      turbine: NREL_ReferenceTurbine_5MW_offshore
+    capacity_per_sqkm: 2
+    correction_factor: 0.8855
+    # proxy for wake losses
+    # from 10.1016/j.energy.2018.08.153
+    # until done more rigorously in #153
+    copernicus:
+      grid_codes: [80, 200]
+    natura: true
+    max_depth: 50
+    max_shore_distance: 30000
+    potential: simple # or conservative
+    clip_p_max_pu: 1.e-2
+    extendable: true
+  offwind-dc:
+    cutout: cutout-2013-era5
+    resource:
+      method: wind
+      turbine: NREL_ReferenceTurbine_5MW_offshore
+    # ScholzPhd Tab 4.3.1: 10MW/km^2
+    capacity_per_sqkm: 3
+    correction_factor: 0.8855
+    # proxy for wake losses
+    # from 10.1016/j.energy.2018.08.153
+    # until done more rigorously in #153
+    copernicus:
+      grid_codes: [80, 200]
+    natura: true
+    max_depth: 50
+    min_shore_distance: 30000
+    potential: simple # or conservative
+    clip_p_max_pu: 1.e-2
+    extendable: true
+  solar:
+    cutout: cutout-2013-era5
+    resource:
+      method: pv
+      panel: CSi
+      orientation: latitude_optimal # will lead into optimal design
+        # slope: 0.  # slope: 0 represent a flat panel
+        # azimuth: 180.  # azimuth: 180 south orientation
+    capacity_per_sqkm: 4.6 # From 1.7 to 4.6 addresses issue #361
+    # Determined by comparing uncorrected area-weighted full-load hours to those
+    # published in Supplementary Data to
+    # Pietzcker, Robert Carl, et al. "Using the sun to decarbonize the power
+    # sector: The economic potential of photovoltaics and concentrating solar
+    # power." Applied Energy 135 (2014): 704-720.
+    correction_factor: 0.854337
+    copernicus:
+      grid_codes: [20, 30, 40, 50, 60, 90, 100]
+    natura: true
+    potential: simple # or conservative
+    clip_p_max_pu: 1.e-2
+    extendable: true
+  hydro:
+    cutout: cutout-2013-era5
+    hydrobasins_level: 6
+    resource:
+      method: hydro
+      hydrobasins: data/hydrobasins/hybas_world.shp
+      flowspeed: 1.0  # m/s
+      # weight_with_height: false
+      # show_progress: true
+    carriers: [ror, PHS, hydro]
+    PHS_max_hours: 6
+    hydro_max_hours: "energy_capacity_totals_by_country"  # not active
+    hydro_max_hours_default: 6.0  # (optional, default 6) Default value of max_hours for hydro when NaN values are found
+    clip_min_inflow: 1.0
+    extendable: true
+    normalization:
+      method: eia  # 'hydro_capacities' to rescale country hydro production by using hydro_capacities, 'eia' to rescale by eia data, false for no rescaling
+      year: 2020  # (optional) year of statistics used to rescale the runoff time series. When not provided, the weather year of the snapshots is used
+    multiplier: 1.1  # multiplier applied after the normalization of the hydro production; default 1.0
+  csp:
+    cutout: cutout-2013-era5
+    resource:
+      method: csp
+      installation: SAM_solar_tower
+    capacity_per_sqkm: 2.392 # From 1.7 to 4.6 addresses issue #361
+    # Determined by comparing uncorrected area-weighted full-load hours to those
+    # published in Supplementary Data to
+    # Pietzcker, Robert Carl, et al. "Using the sun to decarbonize the power
+    # sector: The economic potential of photovoltaics and concentrating solar
+    # power." Applied Energy 135 (2014): 704-720.
+    copernicus:
+      grid_codes: [20, 30, 40, 60, 90]
+      distancing_codes: [50]
+      distance_to_codes: 3000
+    natura: true
+    potential: simple # or conservative
+    clip_p_max_pu: 1.e-2
+    extendable: true
+    csp_model: advanced # simple or advanced
+
+# TODO: Needs to be adjusted for Africa.
+# Costs Configuration (Do not remove, needed for Sphynx documentation).
+costs:
+  year: 2035
+  version: v0.9.2
+  rooftop_share: 0.14  # based on the potentials, assuming  (0.1 kW/m2 and 10 m2/person)
+  USD2013_to_EUR2013: 0.7532 # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html
+  fill_values:
+    FOM: 0
+    VOM: 0
+    efficiency: 1
+    fuel: 0
+    investment: 0
+    lifetime: 25
+    CO2 intensity: 0
+    discount rate: 0.12
+  marginal_cost: # EUR/MWh
+    solar: 0.01
+    onwind: 0.015
+    offwind: 0.015
+    hydro: 0.
+    H2: 0.
+    electrolysis: 0.
+    fuel cell: 0.
+    battery: 0.
+    battery inverter: 0.
+  emission_prices: # in currency per tonne emission, only used with the option Ep
+    co2: 0.
+
+
+monte_carlo:
+  # Description: Specify Monte Carlo sampling options for uncertainty analysis.
+  # Define the option list for Monte Carlo sampling.
+  # Make sure add_to_snakefile is set to true to enable Monte-Carlo
+  options:
+    add_to_snakefile: false # When set to true, enables Monte Carlo sampling
+    samples: 9 # number of optimizations. Note that number of samples when using scipy has to be the square of a prime number
+    sampling_strategy: "chaospy"  # "pydoe2", "chaospy", "scipy", packages that are supported
+    seed: 42 # set seedling for reproducibilty
+  # Uncertanties on any PyPSA object are specified by declaring the specific PyPSA object under the key 'uncertainties'.
+  # For each PyPSA object, the 'type' and 'args' keys represent the type of distribution and its argument, respectively.
+  # Supported distributions types are uniform, normal, lognormal, triangle, beta and gamma.
+  # The arguments of the distribution are passed using the key 'args'  as follows, tailored by distribution type
+  # normal: [mean, std], lognormal: [mean, std], uniform: [lower_bound, upper_bound],
+  # triangle: [mid_point (between 0 - 1)], beta: [alpha, beta], gamma: [shape, scale]
+  # More info on the distributions are documented in the Chaospy reference guide...
+  # https://chaospy.readthedocs.io/en/master/reference/distribution/index.html
+  # An abstract example is as follows:
+  # {pypsa network object, e.g. "loads_t.p_set"}:
+  # type: {any supported distribution among the previous: "uniform", "normal", ...}
+  # args: {arguments passed as a list depending on the distribution, see the above and more at https://pypsa.readthedocs.io/}
+  uncertainties:
+    loads_t.p_set:
+      type: uniform
+      args: [0, 1]
+    generators_t.p_max_pu.loc[:, n.generators.carrier == "onwind"]:
+      type: lognormal
+      args: [1.5]
+    generators_t.p_max_pu.loc[:, n.generators.carrier == "solar"]:
+      type: beta
+      args: [0.5, 2]
+
+
+
+solving:
+  options:
+    formulation: kirchhoff
+    load_shedding: true
+    noisy_costs: true
+    min_iterations: 4
+    max_iterations: 6
+    clip_p_max_pu: 0.01
+    skip_iterations: true
+    track_iterations: false
+    #nhours: 10
+  solver:
+    name: gurobi
+    threads: 4
+    method: 2 # barrier (=ipm)
+    crossover: 0
+    BarConvTol: 1.e-5
+    FeasibilityTol: 1.e-6
+    AggFill: 0
+    PreDual: 0
+    GURO_PAR_BARDENSETHRESH: 200
+
+
+plotting:
+  map:
+    figsize: [7, 7]
+    boundaries: [-10.2, 29, 35, 72]
+    p_nom:
+      bus_size_factor: 5.e+4
+      linewidth_factor: 3.e+3
+
+  costs_max: 800
+  costs_threshold: 1
+
+  energy_max: 15000.
+  energy_min: -10000.
+  energy_threshold: 50.
+
+  vre_techs: ["onwind", "offwind-ac", "offwind-dc", "solar", "ror"]
+  conv_techs: ["OCGT", "CCGT", "nuclear", "coal", "oil"]
+  storage_techs: ["hydro+PHS", "battery", "H2"]
+  load_carriers: ["AC load"]
+  AC_carriers: ["AC line", "AC transformer"]
+  link_carriers: ["DC line", "Converter AC-DC"]
+  tech_colors:
+    "onwind": "#235ebc"
+    "onshore wind": "#235ebc"
+    "offwind": "#6895dd"
+    "offwind-ac": "#6895dd"
+    "offshore wind": "#6895dd"
+    "offshore wind ac": "#6895dd"
+    "offwind-dc": "#74c6f2"
+    "offshore wind dc": "#74c6f2"
+    "hydro": "#08ad97"
+    "hydro+PHS": "#08ad97"
+    "PHS": "#08ad97"
+    "hydro reservoir": "#08ad97"
+    "hydroelectricity": "#08ad97"
+    "ror": "#4adbc8"
+    "run of river": "#4adbc8"
+    "solar": "#f9d002"
+    "solar PV": "#f9d002"
+    "solar thermal": "#ffef60"
+    "biomass": "#0c6013"
+    "solid biomass": "#06540d"
+    "biogas": "#23932d"
+    "waste": "#68896b"
+    "geothermal": "#ba91b1"
+    "OCGT": "#d35050"
+    "gas": "#d35050"
+    "natural gas": "#d35050"
+    "CCGT": "#b20101"
+    "nuclear": "#ff9000"
+    "coal": "#707070"
+    "lignite": "#9e5a01"
+    "oil": "#262626"
+    "H2": "#ea048a"
+    "hydrogen storage": "#ea048a"
+    "battery": "#b8ea04"
+    "Electric load": "#f9d002"
+    "electricity": "#f9d002"
+    "lines": "#70af1d"
+    "transmission lines": "#70af1d"
+    "AC": "#70af1d"
+    "AC-AC": "#70af1d"
+    "AC line": "#70af1d"
+    "links": "#8a1caf"
+    "HVDC links": "#8a1caf"
+    "DC": "#8a1caf"
+    "DC-DC": "#8a1caf"
+    "DC link": "#8a1caf"
+    "load": "#ff0000"
+    "load shedding": "#ff0000"
+    "battery discharger": slategray
+    "battery charger": slategray
+    "h2 fuel cell": '#c251ae'
+    "h2 electrolysis": '#ff29d9'
+    "csp": "#fdd404"
+  nice_names:
+    OCGT: "Open-Cycle Gas"
+    CCGT: "Combined-Cycle Gas"
+    offwind-ac: "Offshore Wind (AC)"
+    offwind-dc: "Offshore Wind (DC)"
+    onwind: "Onshore Wind"
+    solar: "Solar"
+    PHS: "Pumped Hydro Storage"
+    hydro: "Reservoir & Dam"
+    battery: "Battery Storage"
+    H2: "Hydrogen Storage"
+    lines: "Transmission Lines"
+    ror: "Run of River"

--- a/scripts/override_respot.py
+++ b/scripts/override_respot.py
@@ -64,7 +64,7 @@ def override_values(tech, year, dr, simpl, clusters):
 
     def annuity_factor(v):
         return (
-            annuity(v["lifetime"], snakemake.wildcards["discountrate"])
+            annuity(v["lifetime"], float(snakemake.wildcards["discountrate"]))
             + v["fixedomEuroPKW"] / v["investmentEuroPKW"] / 100
         )
 

--- a/scripts/prepare_transport_data_input.py
+++ b/scripts/prepare_transport_data_input.py
@@ -127,6 +127,9 @@ if __name__ == "__main__":
         shutil.copy(src, dest)
     else:
         # Join the DataFrames by the 'country' column
+        CO2_emissions_csv = CO2_emissions_csv[
+            ~CO2_emissions_csv["country"].apply(lambda x: isinstance(x, list))
+        ]
         merged_df = pd.merge(vehicles_csv, CO2_emissions_csv, on="country")
         merged_df = merged_df[["country", "number cars", "average fuel efficiency"]]
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -519,7 +519,7 @@ def fix_rooftopPV_utilityScale_ratio(n, target_ratio=2):
     )
 
     # Filter for rooftop and utility-scale solar generators
-    rooftop_index = n.generators.loc[n.generators.carrier == "rooftop-solar"].index
+    rooftop_index = n.generators.loc[n.generators.carrier == "solar-rooftop"].index
     utility_index = n.generators.loc[n.generators.carrier == "solar"].index
 
     # Get the generator capacity variables (p_nom) for each generator type
@@ -594,7 +594,12 @@ def extra_functionality(n, snapshots):
         "ratio_rooftop_to_utility_solar"
     ]:
         fix_rooftopPV_utilityScale_ratio(
-            n, snakemake.config["policy_config"]["ratio_rooftop_to_utility_solar"]
+            n,
+            float(
+                snakemake.config["policy_config"]["renewables"][
+                    "ratio_rooftop_to_utility_solar"
+                ]
+            ),
         )
 
     add_co2_sequestration_limit(n, snapshots)
@@ -678,8 +683,8 @@ if __name__ == "__main__":
             ll="v1.0",
             opts="Co2L",
             planning_horizons="2035",
-            sopts="365H",
-            discountrate=0.071,
+            sopts="3H",
+            discountrate=0.06,
             demand="BI",
             h2export="0",
             h2mp="endogenous",

--- a/submit_dr.sh
+++ b/submit_dr.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+conda activate pypsa-earth
+
+# rm pypsa-earth/networks/elec.nc
+cp config.pypsa-earth_low.yaml config.pypsa-earth.yaml
+cp config.bright_ref_low.yaml config.yaml
+snakemake --profile slurm all
+cp config.bright_low.yaml config.yaml
+snakemake --profile slurm all
+
+rm pypsa-earth/networks/elec.nc
+cp config.pypsa-earth_med.yaml config.pypsa-earth.yaml
+cp config.bright_ref_med.yaml config.yaml
+snakemake --profile slurm all
+cp config.bright_med.yaml config.yaml
+snakemake --profile slurm all
+
+rm pypsa-earth/networks/elec.nc
+cp config.pypsa-earth_high.yaml config.pypsa-earth.yaml
+cp config.bright_ref_high.yaml config.yaml
+snakemake --profile slurm all
+cp config.bright_high.yaml config.yaml
+snakemake --profile slurm all
+
+rm pypsa-earth/networks/elec.nc
+cp config.pypsa-earth_vhigh.yaml config.pypsa-earth.yaml
+cp config.bright_ref_vhigh.yaml config.yaml
+snakemake --profile slurm all
+cp config.bright_vhigh.yaml config.yaml
+snakemake --profile slurm all
+
+# NEXTCLOUD_URL="https://tubcloud.tu-berlin.de/remote.php/webdav/BRIGHT/results/"
+# USERNAME="cpschau"
+# PASSWORD=$(get_nextcloud_password)
+
+# # Upload the file to Nextcloud via WebDAV
+# tar -czf results_241031.tar.gz /results/241031/
+# curl -u "$USERNAME:$PASSWORD" -T "results_241031.tar.gz" "$NEXTCLOUD_URL"


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR enables the execution of the BRIGHT workflow for four different interest rates: low, medium, high, and very high. Currently, these rates are configured in the configuration files for the pypsa-earth subworkflow, pypsa-earth-sec reference cases, and pypsa-earth-sec export cases. For example, the low-interest rate case uses the files `config.pypsa-earth_low.yaml`, `config.bright_ref_low.yaml`, and `config.bright_low.yaml`. The interest rates currently range from 6% to 12% in 2% increments.

Additionally, several bug fixes have been implemented to ensure the workflow runs smoothly:

1. The pre-processing scripts `prepare_res_potentials` and `override_respot` (for custom renewable potential data) were modified to support the integration of solar-rooftop generators.
2.  The constraint on the ratio between solar and solar-rooftop generation was adjusted to align with the technology naming in `solve_network`.
3. In `prepare_transport_data`, an error-causing row containing country codes for both India and China within a list was removed, as both countries have specific rows elsewhere in the data.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.

